### PR TITLE
Speedup: Use tensordot instead of einsum

### DIFF
--- a/menpofit/transform/modeldriven.py
+++ b/menpofit/transform/modeldriven.py
@@ -262,7 +262,13 @@ class ModelDrivenTransform(Transform, Targetable, Vectorizable,
 
         # dW_dl:  n_points x (n_dims) x n_centres x n_dims
         # dX_dp:  (n_points x n_dims) x n_params
-        dW_dp = np.einsum('ild, lpd -> ipd', self.dW_dl, dX_dp)
+        
+
+        # The following is equivalent to
+        # np.einsum('ild, lpd -> ipd', self.dW_dl, dX_dp)
+        dW_dp = np.tensordot(self.dW_dl, dX_dp, (1, 0))
+        dW_dp = dW_dp.diagonal(axis1=3, axis2=1)
+
         # dW_dp:  n_points x n_params x n_dims
 
         return dW_dp


### PR DESCRIPTION
Einsum uses naive summing and isn't up to par with blas dot routine.
We obtain 87% speedup for the alterative forward additive.

With einstein summation

```
    %%timeit 
    fitter_add.fit(test_img, initial_s, gt_shape=gt_s)
    1 loops, best of 3: 3.95 s per loop 
```

With tensordot

```
    %%timeit 
    fitter_with_optimization.fit(test_img, initial_s, gt_shape=gt_s)
    1 loops, best of 3: 2.11 s per loop 
```
