### PR TITLE
Removes all popup arguments

### DIFF
--- a/menpofit/aam/base.py
+++ b/menpofit/aam/base.py
@@ -183,7 +183,7 @@ class AAM(DeformableModel):
 
     def view_shape_models_widget(self, n_parameters=5,
                                  parameters_bounds=(-3.0, 3.0), mode='multiple',
-                                 popup=False, figure_size=(10, 8)):
+                                 figure_size=(10, 8)):
         r"""
         Visualizes the shape models of the AAM object using the
         `menpo.visualize.widgets.visualize_shape_model` widget.
@@ -212,12 +212,11 @@ class AAM(DeformableModel):
         from menpofit.visualize import visualize_shape_model
         visualize_shape_model(self.shape_models, n_parameters=n_parameters,
                               parameters_bounds=parameters_bounds,
-                              figure_size=figure_size, mode=mode, popup=popup)
+                              figure_size=figure_size, mode=mode)
 
     def view_appearance_models_widget(self, n_parameters=5,
                                       parameters_bounds=(-3.0, 3.0),
-                                      mode='multiple', popup=False,
-                                      figure_size=(10, 8)):
+                                      mode='multiple', figure_size=(10, 8)):
         r"""
         Visualizes the appearance models of the AAM object using the
         `menpo.visualize.widgets.visualize_appearance_model` widget.
@@ -247,12 +246,11 @@ class AAM(DeformableModel):
         visualize_appearance_model(self.appearance_models,
                                    n_parameters=n_parameters,
                                    parameters_bounds=parameters_bounds,
-                                   figure_size=figure_size, mode=mode,
-                                   popup=popup)
+                                   figure_size=figure_size, mode=mode)
 
     def view_aam_widget(self, n_shape_parameters=5, n_appearance_parameters=5,
                         parameters_bounds=(-3.0, 3.0), mode='multiple',
-                        popup=False, figure_size=(10, 8)):
+                        figure_size=(10, 8)):
         r"""
         Visualizes both the shape and appearance models of the AAM object using
         the `menpo.visualize.widgets.visualize_aam` widget.
@@ -290,7 +288,7 @@ class AAM(DeformableModel):
         visualize_aam(self, n_shape_parameters=n_shape_parameters,
                       n_appearance_parameters=n_appearance_parameters,
                       parameters_bounds=parameters_bounds,
-                      figure_size=figure_size, mode=mode, popup=popup)
+                      figure_size=figure_size, mode=mode)
 
     def __str__(self):
         out = "{}\n - {} training images.\n".format(self._str_title,

--- a/menpofit/atm/base.py
+++ b/menpofit/atm/base.py
@@ -168,7 +168,7 @@ class ATM(DeformableModel):
 
     def view_shape_models_widget(self, n_parameters=5,
                                  parameters_bounds=(-3.0, 3.0), mode='multiple',
-                                 popup=False, figure_size=(10, 8)):
+                                 figure_size=(10, 8)):
         r"""
         Visualizes the shape models of the AAM object using the
         `menpo.visualize.widgets.visualize_shape_model` widget.
@@ -197,11 +197,11 @@ class ATM(DeformableModel):
         from menpofit.visualize import visualize_shape_model
         visualize_shape_model(self.shape_models, n_parameters=n_parameters,
                               parameters_bounds=parameters_bounds,
-                              figure_size=figure_size, mode=mode, popup=popup)
+                              figure_size=figure_size, mode=mode)
 
     def view_atm_widget(self, n_shape_parameters=5,
                         parameters_bounds=(-3.0, 3.0), mode='multiple',
-                        popup=False, figure_size=(10, 8)):
+                        figure_size=(10, 8)):
         r"""
         Visualizes the ATM object using the
         menpo.visualize.widgets.visualize_atm widget.
@@ -230,7 +230,7 @@ class ATM(DeformableModel):
         from menpofit.visualize import visualize_atm
         visualize_atm(self, n_shape_parameters=n_shape_parameters,
                       parameters_bounds=parameters_bounds,
-                      figure_size=figure_size, mode=mode, popup=popup)
+                      figure_size=figure_size, mode=mode)
 
     def __str__(self):
         out = "{}\n - {} training shapes.\n".format(self._str_title,

--- a/menpofit/clm/base.py
+++ b/menpofit/clm/base.py
@@ -203,7 +203,7 @@ class CLM(DeformableModel):
 
     def view_shape_models_widget(self, n_parameters=5,
                                  parameters_bounds=(-3.0, 3.0), mode='multiple',
-                                 popup=False, figure_size=(10, 8)):
+                                 figure_size=(10, 8)):
         r"""
         Visualizes the shape models of the CLM object using the
         `menpo.visualize.widgets.visualize_shape_model` widget.
@@ -232,7 +232,7 @@ class CLM(DeformableModel):
         from menpofit.visualize import visualize_shape_model
         visualize_shape_model(self.shape_models, n_parameters=n_parameters,
                               parameters_bounds=parameters_bounds,
-                              figure_size=figure_size, mode=mode, popup=popup)
+                              figure_size=figure_size, mode=mode)
 
     def __str__(self):
         from menpofit.base import name_of_callable

--- a/menpofit/fittingresult.py
+++ b/menpofit/fittingresult.py
@@ -198,7 +198,7 @@ class FittingResult(object):
             raise ValueError('Ground truth has not been set, final error '
                              'cannot be computed')
 
-    def view_widget(self, popup=False, browser_style='buttons'):
+    def view_widget(self, browser_style='buttons'):
         r"""
         Visualizes the multilevel fitting result object using the
         `menpo.visualize.widgets.visualize_fitting_results` widget.
@@ -212,8 +212,7 @@ class FittingResult(object):
             form of plus/minus buttons or a slider.
         """
         from menpofit.visualize import visualize_fitting_results
-        visualize_fitting_results(self, figure_size=(10, 8), popup=popup,
-                                  browser_style=browser_style)
+        visualize_fitting_results(self, figure_size=(10, 8), browser_style=browser_style)
 
     def plot_errors(self, error_type='me_norm', figure_id=None,
                     new_figure=False, render_lines=True, line_colour='b',


### PR DESCRIPTION
`popup` argument was deleted from all widgets but not from the widgets' calls within aam, atm and clm.