### PR TITLE
Copy flag of instance methods

### DIFF
--- a/menpofit/aam/base.py
+++ b/menpofit/aam/base.py
@@ -161,7 +161,7 @@ class AAM(DeformableModel):
         transform = self.transform(
             reference_frame.landmarks['source'].lms, landmarks)
 
-        return appearance_instance.as_unmasked().warp_to_mask(
+        return appearance_instance.as_unmasked(copy=False).warp_to_mask(
             reference_frame.mask, transform, warp_landmarks=True)
 
     def _build_reference_frame(self, reference_shape, landmarks):

--- a/menpofit/atm/base.py
+++ b/menpofit/atm/base.py
@@ -146,7 +146,7 @@ class ATM(DeformableModel):
         transform = self.transform(
             reference_frame.landmarks['source'].lms, landmarks)
 
-        return template.as_unmasked().warp_to_mask(
+        return template.as_unmasked(copy=False).warp_to_mask(
             reference_frame.mask, transform, warp_landmarks=True)
 
     def _build_reference_frame(self, reference_shape, landmarks):


### PR DESCRIPTION
The `instance()` methods of `AAM` and `ATM` require a call of `warp_to_mask`. In order to avoid an `OutOfMaskBoundaryError`, we first need to call `as_unmasked()` on the `appearance_instance` (or the `self.template` respectively). This PR makes sure that `copy=False` when `as_unmasked()` is called.