### PR TITLE
Fix error on fittingresult 

### DIFF
--- a/menpofit/aam/base.py
+++ b/menpofit/aam/base.py
@@ -109,7 +109,7 @@ class AAM(DeformableModel):
         """
         sm = self.shape_models[level]
         am = self.appearance_models[level]
-
+        print(appearance_weights)
         # TODO: this bit of logic should to be transferred down to PCAModel
         if shape_weights is None:
             shape_weights = [0]

--- a/menpofit/aam/base.py
+++ b/menpofit/aam/base.py
@@ -109,7 +109,7 @@ class AAM(DeformableModel):
         """
         sm = self.shape_models[level]
         am = self.appearance_models[level]
-        print(appearance_weights)
+
         # TODO: this bit of logic should to be transferred down to PCAModel
         if shape_weights is None:
             shape_weights = [0]

--- a/menpofit/aam/builder.py
+++ b/menpofit/aam/builder.py
@@ -22,7 +22,7 @@ class AAMBuilder(DeformableModelBuilder):
 
     Parameters
     ----------
-    features : `callable` or ``[callable]``, optional
+    features : `callable` or ``[callable]``, optional0
         If list of length ``n_levels``, feature extraction is performed at
         each level after downscaling of the image.
         The first element of the list specifies the features to be extracted at
@@ -146,7 +146,7 @@ class AAMBuilder(DeformableModelBuilder):
     def __init__(self, features=igo, transform=DifferentiablePiecewiseAffine,
                  trilist=None, normalization_diagonal=None, n_levels=3,
                  downscale=2, scaled_shape_models=True,
-                 max_shape_components=None, max_appearance_components=None,
+                 max_shape_components=None, max_appearance_components=None, appearance_model_method=PCAModel,
                  boundary=3):
         # check parameters
         checks.check_n_levels(n_levels)
@@ -169,6 +169,7 @@ class AAMBuilder(DeformableModelBuilder):
         self.max_shape_components = max_shape_components
         self.max_appearance_components = max_appearance_components
         self.boundary = boundary
+        self.appearance_model_method = appearance_model_method
 
     def build(self, images, group=None, label=None, verbose=False):
         r"""
@@ -294,7 +295,7 @@ class AAMBuilder(DeformableModelBuilder):
             # build appearance model
             if verbose:
                 print_dynamic('{}Building appearance model'.format(level_str))
-            appearance_model = PCAModel(warped_images)
+            appearance_model = self.appearance_model_method(warped_images)
             # trim appearance model if required
             if self.max_appearance_components[rj] is not None:
                 appearance_model.trim_components(
@@ -486,7 +487,7 @@ class PatchBasedAAMBuilder(AAMBuilder):
     def __init__(self, features=igo, patch_shape=(16, 16),
                  normalization_diagonal=None, n_levels=3, downscale=2,
                  scaled_shape_models=True, max_shape_components=None,
-                 max_appearance_components=None, boundary=3):
+                 max_appearance_components=None, boundary=3, appearance_model_method=PCAModel):
         # check parameters
         checks.check_n_levels(n_levels)
         checks.check_downscale(downscale)
@@ -508,6 +509,7 @@ class PatchBasedAAMBuilder(AAMBuilder):
         self.max_shape_components = max_shape_components
         self.max_appearance_components = max_appearance_components
         self.boundary = boundary
+        self.appearance_model_method = appearance_model_method
 
         # patch-based AAMs can only work with TPS transform
         self.transform = DifferentiableThinPlateSplines

--- a/menpofit/aam/builder.py
+++ b/menpofit/aam/builder.py
@@ -118,9 +118,9 @@ class AAMBuilder(DeformableModelBuilder):
         of the reference frame (has potential effects on the gradient
         computation).
 
-    appearance_model_method: `PCAModel`, optional
+    appearance_model_cls: :map:`PCAModel`, optional
         The technique to use to construct an appearance model. Defaults to use
-        PCAModel.
+        `PCAModel` class to do so.
 
     Returns
     -------
@@ -150,7 +150,7 @@ class AAMBuilder(DeformableModelBuilder):
     def __init__(self, features=igo, transform=DifferentiablePiecewiseAffine,
                  trilist=None, normalization_diagonal=None, n_levels=3,
                  downscale=2, scaled_shape_models=True,
-                 max_shape_components=None, max_appearance_components=None, appearance_model_method=PCAModel,
+                 max_shape_components=None, max_appearance_components=None, appearance_model_cls=PCAModel,
                  boundary=3):
         # check parameters
         checks.check_n_levels(n_levels)
@@ -173,7 +173,7 @@ class AAMBuilder(DeformableModelBuilder):
         self.max_shape_components = max_shape_components
         self.max_appearance_components = max_appearance_components
         self.boundary = boundary
-        self.appearance_model_method = appearance_model_method
+        self.appearance_model_cls = appearance_model_cls
 
     def build(self, images, group=None, label=None, verbose=False):
         r"""
@@ -299,7 +299,7 @@ class AAMBuilder(DeformableModelBuilder):
             # build appearance model
             if verbose:
                 print_dynamic('{}Building appearance model'.format(level_str))
-            appearance_model = self.appearance_model_method(warped_images)
+            appearance_model = self.appearance_model_cls(warped_images)
             # trim appearance model if required
             if self.max_appearance_components[rj] is not None:
                 appearance_model.trim_components(
@@ -491,7 +491,7 @@ class PatchBasedAAMBuilder(AAMBuilder):
     def __init__(self, features=igo, patch_shape=(16, 16),
                  normalization_diagonal=None, n_levels=3, downscale=2,
                  scaled_shape_models=True, max_shape_components=None,
-                 max_appearance_components=None, boundary=3, appearance_model_method=PCAModel):
+                 max_appearance_components=None, boundary=3, appearance_model_cls=PCAModel):
         # check parameters
         checks.check_n_levels(n_levels)
         checks.check_downscale(downscale)
@@ -513,7 +513,7 @@ class PatchBasedAAMBuilder(AAMBuilder):
         self.max_shape_components = max_shape_components
         self.max_appearance_components = max_appearance_components
         self.boundary = boundary
-        self.appearance_model_method = appearance_model_method
+        self.appearance_model_cls = appearance_model_cls
 
         # patch-based AAMs can only work with TPS transform
         self.transform = DifferentiableThinPlateSplines

--- a/menpofit/aam/builder.py
+++ b/menpofit/aam/builder.py
@@ -118,6 +118,10 @@ class AAMBuilder(DeformableModelBuilder):
         of the reference frame (has potential effects on the gradient
         computation).
 
+    appearance_model_method: `PCAModel`, optional
+        The technique to use to construct an appearance model. Defaults to use
+        PCAModel.
+
     Returns
     -------
     aam : :map:`AAMBuilder`

--- a/menpofit/fittingresult.py
+++ b/menpofit/fittingresult.py
@@ -518,7 +518,7 @@ class SemiParametricFittingResult(FittingResult):
     """
 
     def __init__(self, image, fitter, parameters=None, gt_shape=None):
-        FittingResult.__init__(self, image, gt_shape=gt_shape)
+        super(SemiParametricFittingResult, self).__init__(image, gt_shape=gt_shape)
         self.fitter = fitter
         self.parameters = parameters
 
@@ -595,8 +595,11 @@ class ParametricFittingResult(SemiParametricFittingResult):
     """
     def __init__(self, image, fitter, parameters=None, weights=None,
                  gt_shape=None):
-        SemiParametricFittingResult.__init__(self, image, fitter, parameters,
-                                             gt_shape=gt_shape)
+
+        super(ParametricFittingResult, self).__init__(
+            image=image, fitter=fitter, parameters=parameters, gt_shape=gt_shape
+        )
+
         self.weights = weights
 
     @property
@@ -668,7 +671,7 @@ class SerializableFittingResult(FittingResult):
         The ground truth shape associated to the image.
     """
     def __init__(self, image, parameters, shapes, gt_shape):
-        FittingResult.__init__(self, image, gt_shape=gt_shape)
+        super(SerializableFittingResult, self).__init__(image, gt_shape=gt_shape)
 
         self.parameters = parameters
         self._shapes = shapes
@@ -913,7 +916,7 @@ class SerializableMultilevelFittingResult(FittingResult):
     """
     def __init__(self, image, fitting_results, gt_shape, n_levels,
                  downscale, n_iters, affine_correction):
-        FittingResult.__init__(self, image, gt_shape=gt_shape)
+        super(SerializableMultilevelFittingResult, self).__init__(image, gt_shape=gt_shape)
         self.fitting_results = fitting_results
         self.n_levels = n_levels
         self._n_iters = n_iters


### PR DESCRIPTION
I came up on an issue while using a patched based AAM where it would crash on a TypeError exception. When using super, instead of calling directly the __init__ method of the base class, fixed the issue.

I also have a change on this branch for an AAM to not only use a PCAModel to model the texture, but rather for the user to provide a class to use. I can make a separate pull request for this, if you like.