### PR TITLE
Bugfix: iterations visualization on fitting result widget

### DIFF
--- a/menpofit/visualize/widgets/base.py
+++ b/menpofit/visualize/widgets/base.py
@@ -2100,7 +2100,7 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
                               'selected_groups': ['final'],
                               'subplots_enabled': True}
     fitting_result_iterations_options = \
-        {'n_iters': fitting_results[0].n_iters,
+        {'n_iters': fitting_results[0].iter_image.landmarks.n_groups,
          'image_has_gt_shape': not fitting_results[0].gt_shape is None,
          'n_points': fitting_results[0].fitted_image.landmarks['final'].lms.n_points,
          'iter_str': 'iter_',
@@ -2527,7 +2527,7 @@ def visualize_fitting_result(fitting_results, figure_size=(10, 8),
 
         # Update iterations result's options
         fitting_result_iterations_options = {
-            'n_iters': fitting_results[value].n_iters,
+            'n_iters': fitting_results[value].iter_image.landmarks.n_groups,
             'image_has_gt_shape': fitting_results[value].gt_shape is not None,
             'n_points':
             fitting_results[value].fitted_image.landmarks['final'].lms.n_points,


### PR DESCRIPTION
The `n_iters` and `shapes` properties of a `FittingResult` object are different, i.e. `len(shapes)` is not equal to `n_iters`. For example, in case we train an AAM with 3 levels and fit it using 50 iterations, then:
* `fitting_result.n_iters == 51`: 50 iterations + the initial shape
* `len(fitting_result.shapes) == 54`: 50 iterations + the initial shape + the initial shapes per level

This PR fixes the `visualize_fitting_result()` widget with respect to the above logic. In the _Info_ tab, the `fitting_result.n_iters` number is printed. However, in the _Iterations_ tab, all the `fitting_result.shapes` are visualized, which wasn't the case till now (we were only visualizing the first `n_iters` shapes!). Note that all the `fitting_result.shapes` shapes are attached to the `LandmarkManager` of `fitting_result.iter_image`, thus `len(fitting_result.shapes) == fitting_result.iter_image.landmarks.n_groups`.