### PR TITLE
Tidy up scales in prepare_image and prepare_template

### DIFF
--- a/menpofit/fitter.py
+++ b/menpofit/fitter.py
@@ -146,11 +146,8 @@ class MultiFitter(object):
                                                  group='initial_shape')
 
         # obtain image representation
-        from copy import deepcopy
-        scales = deepcopy(self.scales)
-        scales.reverse()
         images = []
-        for j, s in enumerate(scales):
+        for j, s in enumerate(self.scales[::-1]):
             if j == 0:
                 # compute features at highest level
                 feature_image = self.features[j](image)

--- a/menpofit/lk/fitter.py
+++ b/menpofit/lk/fitter.py
@@ -59,11 +59,8 @@ class LucasKanadeFitter(MultiFitter):
                 self.diagonal, group=group, label=label)
 
         # obtain image representation
-        from copy import deepcopy
-        scales = deepcopy(self.scales)
-        scales.reverse()
         templates = []
-        for j, s in enumerate(scales):
+        for j, s in enumerate(self.scales[::-1]):
             if j == 0:
                 # compute features at highest level
                 feature_template = self.features[j](template)


### PR DESCRIPTION
Simple "tidy up" of `scales` in the `prepare_image` and `prepare_template` methods of `Fitters`.