### PR TITLE
Fix pickling SDMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,11 @@ env:
     - PYTHON_VERSION: 3.4
 
 install:
-- wget https://raw.githubusercontent.com/menpo/condaci/v0.3.0/condaci.py -O condaci.py
-- python condaci.py setup $PYTHON_VERSION --channel $BINSTAR_USER
-- export PATH=$HOME/miniconda/bin:$PATH
+  - wget https://raw.githubusercontent.com/menpo/condaci/v0.4.1/condaci.py -O condaci.py
+  - python condaci.py setup
 
 script:
-- python condaci.py auto ./conda --binstaruser $BINSTAR_USER --binstarkey $BINSTAR_KEY
+  - ~/miniconda/bin/python condaci.py build ./conda
 
 notifications:
   slack:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,15 +13,15 @@ matrix:
    fast_finish: true
 
 platform:
-- x86
-- x64
+  - x86
+  - x64
 
 init:
-- ps: Start-FileDownload 'https://raw.githubusercontent.com/menpo/condaci/v0.3.0/condaci.py' C:\\condaci.py; echo "Done"
-- cmd: python C:\\condaci.py setup %PYTHON_VERSION% --channel %BINSTAR_USER%
+  - ps: Start-FileDownload 'https://raw.githubusercontent.com/menpo/condaci/v0.4.1/condaci.py' C:\\condaci.py; echo "Done"
+  - cmd: python C:\\condaci.py setup
 
 install:
-- cmd: C:\\Miniconda\\python C:\\condaci.py auto ./conda --binstaruser %BINSTAR_USER% --binstarkey %BINSTAR_KEY%
+  - cmd: C:\\Miniconda\\python C:\\condaci.py build ./conda
 
 notifications:
   - provider: Slack

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -16,7 +16,7 @@ test:
   requires:
   - coverage
   - nose
-  - mock
+  - mock 1.0.1
 
   imports:
   - menpofit

--- a/menpofit/regression/parametricfeatures.py
+++ b/menpofit/regression/parametricfeatures.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 def extract_parametric_features(appearance_model, warped_image,
                                 rergession_features):
     r"""
@@ -120,3 +123,54 @@ def project_out(appearance_model, warped_image):
     """
     diff = warped_image.as_vector() - appearance_model.mean().as_vector()
     return appearance_model.distance_to_subspace_vector(diff).ravel()
+
+
+class nonparametric_regression_features(object):
+
+    def __init__(self, patch_shape, feature_patch_length, regression_features):
+        self.patch_shape = patch_shape
+        self.feature_patch_length = feature_patch_length
+        self.regression_features = regression_features
+
+    def __call__(self, image, shape):
+        # extract patches
+        patches = image.extract_patches(shape, patch_size=self.patch_shape)
+
+        features = np.zeros((shape.n_points, self.feature_patch_length))
+        for j, patch in enumerate(patches):
+            # compute features
+            features[j, ...] = self.regression_features(patch).as_vector()
+
+        return np.hstack((features.ravel(), 1))
+
+
+class parametric_regression_features(object):
+
+    def __init__(self, transform, template, appearance_model,
+                 regression_features):
+        self.transform = transform
+        self.template = template
+        self.appearance_model = appearance_model
+        self.regression_features = regression_features
+
+    def __call__(self, image, shape):
+        self.transform.set_target(shape)
+        # TODO should the template be a mask or a shape? warp_to_shape here
+        warped_image = image.warp_to_mask(self.template.mask, self.transform,
+                                          warp_landmarks=False)
+        features = extract_parametric_features(
+            self.appearance_model, warped_image, self.regression_features)
+        return np.hstack((features, 1))
+
+
+class semiparametric_classifier_regression_features(object):
+
+    def __init__(self, patch_shape, classifiers):
+        self.patch_shape = patch_shape
+        self.classifiers = classifiers
+
+    def __call__(self, image, shape):
+        patches = image.extract_patches(shape, patch_size=self.patch_shape)
+        features = [clf(patch.as_vector(keep_channels=True))
+                    for (clf, patch) in zip(self.classifiers, patches)]
+        return np.hstack((np.asarray(features).ravel(), 1))

--- a/menpofit/regression/regressors.py
+++ b/menpofit/regression/regressors.py
@@ -13,9 +13,10 @@ class mlr(object):
     T: numpy.array
         The shapes differential that denote the dependent variable.
     """
-    def __init__(self, X, T):
+    def __init__(self, X, T, lmda=0):
         XX = np.dot(X.T, X)
-        XX = (XX + XX.T) / 2
+        if lmda > 0:
+            np.fill_diagonal(XX, lmda + np.diag(XX))
         XT = np.dot(X.T, T)
         self.R = np.linalg.solve(XX, XT)
 

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(name='menpofit',
       packages=find_packages(),
       install_requires=['menpo>=0.5.1,<0.6',
                         'scikit-learn>=0.16,<0.17'],
-      tests_require=['nose', 'mock']
+      tests_require=['nose', 'mock==1.0.1']
       )


### PR DESCRIPTION
There was a bug whereby we were passing the features method
of the regressors into the SDM, which is not pickeable because
the method will be unbound when being serialized. I just
abstracted that into a callable to capture the state
and added a new method to return this new callable rather than
passing a reference to it.