### PR TITLE
Features naming

### DIFF
--- a/menpofit/aam/algorithm/lk.py
+++ b/menpofit/aam/algorithm/lk.py
@@ -162,10 +162,9 @@ class LucasKanadePatchBaseInterface(LucasKanadeBaseInterface):
     r"""
     """
     def __init__(self, transform, template, sampling=None,
-                 patch_size=(17, 17), normalize_parts=no_op):
+                 patch_size=(17, 17), patch_normalisation=no_op):
         self.patch_size = patch_size
-        # TODO: Refactor to patch_features
-        self.normalize_parts = normalize_parts
+        self.patch_normalisation = patch_normalisation
 
         super(LucasKanadePatchBaseInterface, self).__init__(
             transform, template, sampling=sampling)
@@ -194,7 +193,7 @@ class LucasKanadePatchBaseInterface(LucasKanadeBaseInterface):
         parts = image.extract_patches(self.transform.target,
                                       patch_size=self.patch_size,
                                       as_single_array=True)
-        parts = self.normalize_parts(parts)
+        parts = self.patch_normalisation(parts)
         return Image(parts, copy=False)
 
     def gradient(self, image):
@@ -228,13 +227,12 @@ class LucasKanadePatchInterface(LucasKanadePatchBaseInterface):
     r"""
     """
     def __init__(self, appearance_model, transform, template, sampling=None,
-                 patch_size=(17, 17), normalize_parts=no_op):
-        # TODO: Refactor to patch_features
+                 patch_size=(17, 17), patch_normalisation=no_op):
         self.appearance_model = appearance_model
 
         super(LucasKanadePatchInterface, self).__init__(
             transform, template, patch_size=patch_size,
-            normalize_parts=normalize_parts, sampling=sampling)
+            patch_normalisation=patch_normalisation, sampling=sampling)
 
     @property
     def m(self):

--- a/menpofit/aam/algorithm/sd.py
+++ b/menpofit/aam/algorithm/sd.py
@@ -74,7 +74,7 @@ class SupervisedDescentLinearInterface(SupervisedDescentStandardInterface):
 
 
 # TODO document me!
-class SupervisedDescentPartsInterface(SupervisedDescentStandardInterface):
+class SupervisedDescentPatchInterface(SupervisedDescentStandardInterface):
     r"""
     """
     def __init__(self, appearance_model, transform, template, sampling=None,
@@ -82,7 +82,7 @@ class SupervisedDescentPartsInterface(SupervisedDescentStandardInterface):
         self.patch_size = patch_size
         self.patch_normalisation = patch_normalisation
 
-        super(SupervisedDescentPartsInterface, self).__init__(
+        super(SupervisedDescentPatchInterface, self).__init__(
             appearance_model, transform, template, sampling=sampling)
 
     def _build_sampling_mask(self, sampling):

--- a/menpofit/aam/algorithm/sd.py
+++ b/menpofit/aam/algorithm/sd.py
@@ -78,10 +78,9 @@ class SupervisedDescentPartsInterface(SupervisedDescentStandardInterface):
     r"""
     """
     def __init__(self, appearance_model, transform, template, sampling=None,
-                 patch_size=(17, 17), normalize_parts=no_op):
+                 patch_size=(17, 17), patch_normalisation=no_op):
         self.patch_size = patch_size
-        # TODO: Refactor to patch_features
-        self.normalize_parts = normalize_parts
+        self.patch_normalisation = patch_normalisation
 
         super(SupervisedDescentPartsInterface, self).__init__(
             appearance_model, transform, template, sampling=sampling)
@@ -103,7 +102,7 @@ class SupervisedDescentPartsInterface(SupervisedDescentStandardInterface):
         parts = image.extract_patches(self.transform.target,
                                       patch_size=self.patch_size,
                                       as_single_array=True)
-        parts = self.normalize_parts(parts)
+        parts = self.patch_normalisation(parts)
         return Image(parts, copy=False)
 
 

--- a/menpofit/aam/fitter.py
+++ b/menpofit/aam/fitter.py
@@ -14,7 +14,7 @@ from .algorithm.lk import (
     LucasKanadePatchInterface, WibergInverseCompositional)
 from .algorithm.sd import (
     SupervisedDescentStandardInterface, SupervisedDescentLinearInterface,
-    SupervisedDescentPartsInterface, ProjectOutNewton)
+    SupervisedDescentPatchInterface, ProjectOutNewton)
 from .result import AAMFitterResult
 
 
@@ -143,7 +143,7 @@ class SupervisedDescentAAMFitter(SupervisedDescentFitter):
             elif type(self.aam) is PatchAAM:
                 # Build orthogonal point distribution model
                 pdm = OrthoPDM(sm)
-                interface = SupervisedDescentPartsInterface(
+                interface = SupervisedDescentPatchInterface(
                     am, pdm, template, sampling=s,
                     patch_size=self.aam.patch_size[j],
                     patch_normalisation=self.aam.patch_normalisation)

--- a/menpofit/aam/fitter.py
+++ b/menpofit/aam/fitter.py
@@ -76,7 +76,7 @@ class LucasKanadeAAMFitter(AAMFitter):
                 interface = LucasKanadePatchInterface(
                     am, pdm, template, sampling=s,
                     patch_size=self.aam.patch_size[j],
-                    normalize_parts=self.aam.normalize_parts)
+                    patch_normalisation=self.aam.patch_normalisation)
                 algorithm = lk_algorithm_cls(interface)
             else:
                 raise ValueError("AAM object must be of one of the "
@@ -109,7 +109,7 @@ class SupervisedDescentAAMFitter(SupervisedDescentFitter):
             images, group=group, bounding_box_group=bounding_box_group,
             reference_shape=self.aam.reference_shape,
             sd_algorithm_cls=sd_algorithm_cls,
-            holistic_feature=self.aam.features,
+            holistic_feature=self.aam.holistic_features,
             diagonal=self.aam.diagonal,
             scales=self.aam.scales, n_iterations=n_iterations,
             n_perturbations=n_perturbations,
@@ -146,7 +146,7 @@ class SupervisedDescentAAMFitter(SupervisedDescentFitter):
                 interface = SupervisedDescentPartsInterface(
                     am, pdm, template, sampling=s,
                     patch_size=self.aam.patch_size[j],
-                    normalize_parts=self.aam.normalize_parts)
+                    patch_normalisation=self.aam.patch_normalisation)
                 algorithm = self._sd_algorithm_cls(
                     interface, n_iterations=self.n_iterations[j])
             else:

--- a/menpofit/atm/fitter.py
+++ b/menpofit/atm/fitter.py
@@ -47,7 +47,7 @@ class LucasKanadeATMFitter(ModelFitter):
                 pdm = OrthoPDM(sm)
                 interface = ATMLKPatchInterface(
                     pdm, wt, sampling=s, patch_size=self.atm.patch_size[j],
-                    normalize_parts=self.atm.normalize_parts)
+                    patch_normalisation=self.atm.patch_normalisation)
                 algorithm = algorithm_cls(interface)
             else:
                 raise ValueError("AAM object must be of one of the "

--- a/menpofit/builder.py
+++ b/menpofit/builder.py
@@ -159,7 +159,7 @@ def warp_images(images, shapes, reference_frame, transform, prefix='',
 
 
 # TODO: document me!
-def extract_patches(images, shapes, patch_size, normalize_function=no_op,
+def extract_patches(images, shapes, patch_size, normalise_function=no_op,
                     prefix='', verbose=False):
     wrap = partial(print_progress,
                    prefix='{}Extracting patches'.format(prefix),
@@ -169,8 +169,8 @@ def extract_patches(images, shapes, patch_size, normalize_function=no_op,
     for i, s in wrap(zip(images, shapes)):
         parts = i.extract_patches(s, patch_size=patch_size,
                                   as_single_array=True)
-        parts = normalize_function(parts)
-        parts_images.append(Image(parts))
+        parts = normalise_function(parts)
+        parts_images.append(Image(parts, copy=False))
     return parts_images
 
 def build_reference_frame(landmarks, boundary=3, group='source'):

--- a/menpofit/clm/base.py
+++ b/menpofit/clm/base.py
@@ -27,14 +27,15 @@ class CLM(object):
         The CLM object
     """
     def __init__(self, images, group=None, verbose=False, batch_size=None,
-                 diagonal=None, scales=(0.5, 1), features=no_op,
+                 diagonal=None, scales=(0.5, 1), holistic_features=no_op,
                  # shape_model_cls=build_normalised_pca_shape_model,
                  expert_ensemble_cls=CorrelationFilterExpertEnsemble,
                  max_shape_components=None, reference_shape=None,
                  shape_forgetting_factor=1.0):
         self.diagonal = checks.check_diagonal(diagonal)
         self.scales = checks.check_scales(scales)
-        self.features = checks.check_features(features, self.n_scales)
+        self.holistic_features = checks.check_features(holistic_features,
+                                                       self.n_scales)
         # self.shape_model_cls = checks.check_algorithm_cls(
         #     shape_model_cls, self.n_scales, ShapeModel)
         self.expert_ensemble_cls = checks.check_algorithm_cls(
@@ -125,15 +126,15 @@ class CLM(object):
                 prefix = None
 
             # Handle holistic features
-            if i == 0 and self.features[i] == no_op:
+            if i == 0 and self.holistic_features[i] == no_op:
                 # Saves a lot of memory
                 feature_images = image_batch
-            elif i == 0 or self.features[i] is not self.features[i - 1]:
+            elif i == 0 or self.holistic_features[i] is not self.holistic_features[i - 1]:
                 # compute features only if this is the first pass through
                 # the loop or the features at this scale are different from
                 # the features at the previous scale
                 feature_images = compute_features(image_batch,
-                                                  self.features[i],
+                                                  self.holistic_features[i],
                                                   prefix=prefix,
                                                   verbose=verbose)
             # handle scales

--- a/menpofit/clm/expert/ensemble.py
+++ b/menpofit/clm/expert/ensemble.py
@@ -93,7 +93,7 @@ class ConvolutionBasedExpertEnsemble(ExpertEnsemble):
         # patch: (offsets x ch) x h x w
         patch = patch.reshape((-1,) + patch.shape[-2:])
         # Normalise patch
-        return self.normalise_callable(patch)
+        return self.patch_normalisation(patch)
 
     def _extract_patches(self, image, shape):
         r"""
@@ -107,7 +107,7 @@ class ConvolutionBasedExpertEnsemble(ExpertEnsemble):
         # patches: n_patches x (n_offsets x n_channels) x height x width
         patches = patches.reshape((patches.shape[0], -1) + patches.shape[-2:])
         # Normalise patches
-        return self.normalise_callable(patches)
+        return self.patch_normalisation(patches)
 
     def predict_response(self, image, shape):
         r"""
@@ -134,7 +134,7 @@ class CorrelationFilterExpertEnsemble(ConvolutionBasedExpertEnsemble):
     def __init__(self, images, shapes, verbose=False, prefix='',
                  icf_cls=IncrementalCorrelationFilterThinWrapper,
                  patch_size=(17, 17), context_size=(34, 34),
-                 response_covariance=3, normalise_callable=normalize_norm,
+                 response_covariance=3, patch_normalisation=normalize_norm,
                  cosine_mask=True, sample_offsets=None):
         # TODO: check parameters?
         # Set parameters
@@ -142,7 +142,7 @@ class CorrelationFilterExpertEnsemble(ConvolutionBasedExpertEnsemble):
         self.patch_size = patch_size
         self.context_size = context_size
         self.response_covariance = response_covariance
-        self.normalise_callable = normalise_callable
+        self.patch_normalisation = patch_normalisation
         self.cosine_mask = cosine_mask
         self.sample_offsets = sample_offsets
 
@@ -168,7 +168,7 @@ class CorrelationFilterExpertEnsemble(ConvolutionBasedExpertEnsemble):
         # patch: (offsets x ch) x h x w
         patch = patch.reshape((-1,) + patch.shape[-2:])
         # Normalise patch
-        patch = self.normalise_callable(patch)
+        patch = self.patch_normalisation(patch)
         if self.cosine_mask:
             # Apply cosine mask if require
             patch = self._cosine_mask * patch

--- a/menpofit/fitter.py
+++ b/menpofit/fitter.py
@@ -141,11 +141,11 @@ class MultiFitter(object):
         images = []
         for i in range(self.n_scales):
             # Handle features
-            if i == 0 or self.features[i] is not self.features[i - 1]:
+            if i == 0 or self.holistic_features[i] is not self.holistic_features[i - 1]:
                 # Compute features only if this is the first pass through
                 # the loop or the features at this scale are different from
                 # the features at the previous scale
-                feature_image = self.features[i](image)
+                feature_image = self.holistic_features[i](image)
 
             # Handle scales
             if self.scales[i] != 1:
@@ -246,10 +246,10 @@ class ModelFitter(MultiFitter):
         return self._model.reference_shape
 
     @property
-    def features(self):
+    def holistic_features(self):
         r"""
         """
-        return self._model.features
+        return self._model.holistic_features
 
     @property
     def scales(self):

--- a/menpofit/lk/fitter.py
+++ b/menpofit/lk/fitter.py
@@ -13,16 +13,17 @@ from .result import LucasKanadeFitterResult
 class LucasKanadeFitter(MultiFitter):
     r"""
     """
-    def __init__(self, template, group=None, features=no_op,
+    def __init__(self, template, group=None, holistic_features=no_op,
                  transform_cls=DifferentiableAlignmentAffine, diagonal=None,
                  scales=(0.5, 1.0), algorithm_cls=InverseCompositional,
                  residual_cls=SSD):
 
         checks.check_diagonal(diagonal)
         scales = checks.check_scales(scales)
-        features = checks.check_features(features, len(scales))
+        holistic_features = checks.check_features(holistic_features,
+                                                  len(scales))
 
-        self.features = features
+        self.holistic_features = holistic_features
         self.transform_cls = transform_cls
         self.diagonal = diagonal
         self.scales = list(scales)

--- a/menpofit/sdm/algorithm.py
+++ b/menpofit/sdm/algorithm.py
@@ -44,7 +44,7 @@ class SupervisedDescentAlgorithm(object):
         for k in range(self.n_iterations):
             # generate regression data
             features = features_per_image(
-                images, current_shapes, self.patch_size, self.features,
+                images, current_shapes, self.patch_size, self.patch_features,
                 prefix='{}(Iteration {}) - '.format(prefix, k),
                 verbose=verbose)
 
@@ -89,8 +89,8 @@ class SupervisedDescentAlgorithm(object):
         # Cascaded Regression loop
         for r in self.regressors:
             # compute regression features
-            features = features_per_patch(image, current_shape,
-                                          self.patch_size, self.features)
+            features = features_per_patch(image, current_shape, self.patch_size,
+                                          self.patch_features)
 
             # solve for increments on the shape vector
             dx = r.predict(features)
@@ -127,14 +127,15 @@ class SupervisedDescentAlgorithm(object):
 class Newton(SupervisedDescentAlgorithm):
     r"""
     """
-    def __init__(self, features=no_op, patch_size=(17, 17), n_iterations=3,
+    def __init__(self, patch_features=no_op, patch_size=(17, 17),
+                 n_iterations=3,
                  compute_error=compute_normalise_point_to_point_error,
                  eps=10**-5, alpha=0, bias=True):
         super(Newton, self).__init__()
 
         self._regressor_cls = partial(IRLRegression, alpha=alpha, bias=bias)
         self.patch_size = patch_size
-        self.features = features
+        self.patch_features = patch_features
         self.n_iterations = n_iterations
         self._compute_error = compute_error
         self.eps = eps
@@ -144,7 +145,7 @@ class Newton(SupervisedDescentAlgorithm):
 class GaussNewton(SupervisedDescentAlgorithm):
     r"""
     """
-    def __init__(self, features=no_op, patch_size=(17, 17), n_iterations=3,
+    def __init__(self, patch_features=no_op, patch_size=(17, 17), n_iterations=3,
                  compute_error=compute_normalise_point_to_point_error,
                  eps=10**-5, alpha=0, bias=True, alpha2=0):
         super(GaussNewton, self).__init__()
@@ -152,7 +153,7 @@ class GaussNewton(SupervisedDescentAlgorithm):
         self._regressor_cls = partial(IIRLRegression, alpha=alpha, bias=bias,
                                       alpha2=alpha2)
         self.patch_size = patch_size
-        self.features = features
+        self.patch_features = patch_features
         self.n_iterations = n_iterations
         self._compute_error = compute_error
         self.eps = eps

--- a/menpofit/visualize/widgets/base.py
+++ b/menpofit/visualize/widgets/base.py
@@ -961,7 +961,7 @@ def visualize_aam(aam, n_shape_parameters=5, n_appearance_parameters=5,
         aam_mean = lvl_app_mod.mean()
         n_channels = aam_mean.n_channels
         tmplt_inst = lvl_app_mod.template_instance
-        feat = aam.features[level]
+        feat = aam.holistic_features[level]
 
         # Feature string
         tmp_feat = 'Feature is {} with {} channel{}'.format(
@@ -1355,7 +1355,7 @@ def visualize_atm(atm, n_shape_parameters=5, mode='multiple',
         lvl_shape_mod = atm.shape_models[level]
         tmplt_inst = atm.warped_templates[level]
         n_channels = tmplt_inst.n_channels
-        feat = atm.features[level]
+        feat = atm.holistic_features[level]
 
         # Feature string
         tmp_feat = 'Feature is {} with {} channel{}'.format(


### PR DESCRIPTION
Trying to make the features parameter naming consistent:

`features` -> `holistic_features`
`normalize_parts` -> `patch_normalisation`
`normalise_callable` -> `patch_normalisation`
`patch_features` -> `patch_features`

At the moment, only SDMs have patch_features due to the lack
of distinction on menpo between image and vector features.