### PR TITLE
Rename patch_size to patch_shape

### DIFF
--- a/menpofit/aam/algorithm/lk.py
+++ b/menpofit/aam/algorithm/lk.py
@@ -162,8 +162,8 @@ class LucasKanadePatchBaseInterface(LucasKanadeBaseInterface):
     r"""
     """
     def __init__(self, transform, template, sampling=None,
-                 patch_size=(17, 17), patch_normalisation=no_op):
-        self.patch_size = patch_size
+                 patch_shape=(17, 17), patch_normalisation=no_op):
+        self.patch_shape = patch_shape
         self.patch_normalisation = patch_normalisation
 
         super(LucasKanadePatchBaseInterface, self).__init__(
@@ -171,7 +171,7 @@ class LucasKanadePatchBaseInterface(LucasKanadeBaseInterface):
 
     def _build_sampling_mask(self, sampling):
         if sampling is None:
-            sampling = np.ones(self.patch_size, dtype=np.bool)
+            sampling = np.ones(self.patch_shape, dtype=np.bool)
 
         image_shape = self.template.pixels.shape
         image_mask = np.tile(sampling[None, None, None, ...],
@@ -191,14 +191,14 @@ class LucasKanadePatchBaseInterface(LucasKanadeBaseInterface):
 
     def warp(self, image):
         parts = image.extract_patches(self.transform.target,
-                                      patch_size=self.patch_size,
+                                      patch_shape=self.patch_shape,
                                       as_single_array=True)
         parts = self.patch_normalisation(parts)
         return Image(parts, copy=False)
 
     def gradient(self, image):
         pixels = image.pixels
-        nabla = fast_gradient(pixels.reshape((-1,) + self.patch_size))
+        nabla = fast_gradient(pixels.reshape((-1,) + self.patch_shape))
         # remove 1st dimension gradient which corresponds to the gradient
         # between parts
         return nabla.reshape((2,) + pixels.shape)
@@ -227,11 +227,11 @@ class LucasKanadePatchInterface(LucasKanadePatchBaseInterface):
     r"""
     """
     def __init__(self, appearance_model, transform, template, sampling=None,
-                 patch_size=(17, 17), patch_normalisation=no_op):
+                 patch_shape=(17, 17), patch_normalisation=no_op):
         self.appearance_model = appearance_model
 
         super(LucasKanadePatchInterface, self).__init__(
-            transform, template, patch_size=patch_size,
+            transform, template, patch_shape=patch_shape,
             patch_normalisation=patch_normalisation, sampling=sampling)
 
     @property

--- a/menpofit/aam/algorithm/sd.py
+++ b/menpofit/aam/algorithm/sd.py
@@ -78,8 +78,8 @@ class SupervisedDescentPatchInterface(SupervisedDescentStandardInterface):
     r"""
     """
     def __init__(self, appearance_model, transform, template, sampling=None,
-                 patch_size=(17, 17), patch_normalisation=no_op):
-        self.patch_size = patch_size
+                 patch_shape=(17, 17), patch_normalisation=no_op):
+        self.patch_shape = patch_shape
         self.patch_normalisation = patch_normalisation
 
         super(SupervisedDescentPatchInterface, self).__init__(
@@ -87,7 +87,7 @@ class SupervisedDescentPatchInterface(SupervisedDescentStandardInterface):
 
     def _build_sampling_mask(self, sampling):
         if sampling is None:
-            sampling = np.ones(self.patch_size, dtype=np.bool)
+            sampling = np.ones(self.patch_shape, dtype=np.bool)
 
         image_shape = self.template.pixels.shape
         image_mask = np.tile(sampling[None, None, None, ...],
@@ -100,7 +100,7 @@ class SupervisedDescentPatchInterface(SupervisedDescentStandardInterface):
 
     def warp(self, image):
         parts = image.extract_patches(self.transform.target,
-                                      patch_size=self.patch_size,
+                                      patch_shape=self.patch_shape,
                                       as_single_array=True)
         parts = self.patch_normalisation(parts)
         return Image(parts, copy=False)

--- a/menpofit/aam/base.py
+++ b/menpofit/aam/base.py
@@ -467,10 +467,10 @@ class MaskedAAM(AAM):
 
     def __init__(self, images, group=None, verbose=False, reference_shape=None,
                  holistic_features=no_op, diagonal=None, scales=(0.5, 1.0),
-                 patch_size=(17, 17), max_shape_components=None,
+                 patch_shape=(17, 17), max_shape_components=None,
                  max_appearance_components=None, batch_size=None):
         n_scales = len(checks.check_scales(scales))
-        self.patch_size = checks.check_patch_size(patch_size, n_scales)
+        self.patch_shape = checks.check_patch_shape(patch_shape, n_scales)
 
         super(MaskedAAM, self).__init__(
             images, group=group, verbose=verbose,
@@ -484,7 +484,7 @@ class MaskedAAM(AAM):
     def _warp_images(self, images, shapes, reference_shape, scale_index,
                      prefix, verbose):
         reference_frame = build_patch_reference_frame(
-            reference_shape, patch_size=self.patch_size[scale_index])
+            reference_shape, patch_shape=self.patch_shape[scale_index])
         return warp_images(images, shapes, reference_frame, self.transform,
                            prefix=prefix, verbose=verbose)
 
@@ -497,7 +497,7 @@ class MaskedAAM(AAM):
         landmarks = template.landmarks['source'].lms
 
         reference_frame = build_patch_reference_frame(
-            shape_instance, patch_size=self.patch_size)
+            shape_instance, patch_shape=self.patch_shape)
 
         transform = self.transform(
             reference_frame.landmarks['source'].lms, landmarks)
@@ -600,10 +600,10 @@ class LinearMaskedAAM(AAM):
 
     def __init__(self, images, group=None, verbose=False, reference_shape=None,
                  holistic_features=no_op, diagonal=None, scales=(0.5, 1.0),
-                 patch_size=(17, 17), max_shape_components=None,
+                 patch_shape=(17, 17), max_shape_components=None,
                  max_appearance_components=None, batch_size=None):
         n_scales = len(checks.check_scales(scales))
-        self.patch_size = checks.check_patch_size(patch_size, n_scales)
+        self.patch_shape = checks.check_patch_shape(patch_shape, n_scales)
 
         super(LinearMaskedAAM, self).__init__(
             images, group=group, verbose=verbose,
@@ -626,7 +626,7 @@ class LinearMaskedAAM(AAM):
         mean_aligned_shape = mean_pointcloud(align_shapes(shapes))
         self.n_landmarks = mean_aligned_shape.n_points
         self.reference_frame = build_patch_reference_frame(
-            mean_aligned_shape, patch_size=self.patch_size[scale_index])
+            mean_aligned_shape, patch_shape=self.patch_shape[scale_index])
         dense_shapes = densify_shapes(shapes, self.reference_frame,
                                       self.transform)
         # build dense shape model
@@ -677,11 +677,11 @@ class PatchAAM(AAM):
 
     def __init__(self, images, group=None, verbose=False, reference_shape=None,
                  holistic_features=no_op, patch_normalisation=no_op,
-                 diagonal=None, scales=(0.5, 1.0), patch_size=(17, 17),
+                 diagonal=None, scales=(0.5, 1.0), patch_shape=(17, 17),
                  max_shape_components=None, max_appearance_components=None,
                  batch_size=None):
         n_scales = len(checks.check_scales(scales))
-        self.patch_size = checks.check_patch_size(patch_size, n_scales)
+        self.patch_shape = checks.check_patch_shape(patch_shape, n_scales)
         self.patch_normalisation = patch_normalisation
 
         super(PatchAAM, self).__init__(
@@ -703,7 +703,7 @@ class PatchAAM(AAM):
 
     def _warp_images(self, images, shapes, reference_shape, scale_index,
                      prefix, verbose):
-        return extract_patches(images, shapes, self.patch_size[scale_index],
+        return extract_patches(images, shapes, self.patch_shape[scale_index],
                                normalise_function=self.patch_normalisation,
                                prefix=prefix, verbose=verbose)
 
@@ -746,10 +746,10 @@ def _aam_str(aam):
             aam.appearance_models[k].n_components,
             aam.shape_models[k].n_components))
     # Patch based AAM
-    if hasattr(aam, 'patch_size'):
+    if hasattr(aam, 'patch_shape'):
         for k in range(len(scales_info)):
-            scales_info[k] += '\n   - Patch size: {}'.format(
-                aam.patch_size[k])
+            scales_info[k] += '\n   - Patch shape: {}'.format(
+                aam.patch_shape[k])
     scales_info = '\n'.join(scales_info)
 
     if aam.transform is not None:

--- a/menpofit/aam/fitter.py
+++ b/menpofit/aam/fitter.py
@@ -75,7 +75,7 @@ class LucasKanadeAAMFitter(AAMFitter):
                 pdm = OrthoPDM(sm)
                 interface = LucasKanadePatchInterface(
                     am, pdm, template, sampling=s,
-                    patch_size=self.aam.patch_size[j],
+                    patch_shape=self.aam.patch_shape[j],
                     patch_normalisation=self.aam.patch_normalisation)
                 algorithm = lk_algorithm_cls(interface)
             else:
@@ -102,7 +102,7 @@ class SupervisedDescentAAMFitter(SupervisedDescentFitter):
         checks.set_models_components(aam.shape_models, n_shape)
         self._sampling = checks.check_sampling(sampling, aam.n_scales)
 
-        # patch_feature and patch_size are not actually
+        # patch_feature and patch_shape are not actually
         # used because they are fully defined by the AAM already. Therefore,
         # we just leave them as their 'defaults' because they won't be used.
         super(SupervisedDescentAAMFitter, self).__init__(
@@ -145,7 +145,7 @@ class SupervisedDescentAAMFitter(SupervisedDescentFitter):
                 pdm = OrthoPDM(sm)
                 interface = SupervisedDescentPatchInterface(
                     am, pdm, template, sampling=s,
-                    patch_size=self.aam.patch_size[j],
+                    patch_shape=self.aam.patch_shape[j],
                     patch_normalisation=self.aam.patch_normalisation)
                 algorithm = self._sd_algorithm_cls(
                     interface, n_iterations=self.n_iterations[j])

--- a/menpofit/atm/base.py
+++ b/menpofit/atm/base.py
@@ -356,9 +356,9 @@ class MaskedATM(ATM):
 
     def __init__(self, template, shapes, group=None, verbose=False,
                  holistic_features=no_op, diagonal=None, scales=(0.5, 1.0),
-                 patch_size=(17, 17), max_shape_components=None,
+                 patch_shape=(17, 17), max_shape_components=None,
                  batch_size=None):
-        self.patch_size = checks.check_patch_size(patch_size, len(scales))
+        self.patch_shape = checks.check_patch_shape(patch_shape, len(scales))
 
         super(MaskedATM, self).__init__(
             template, shapes, group=group, verbose=verbose,
@@ -370,7 +370,7 @@ class MaskedATM(ATM):
     def _warp_template(self, template, group, reference_shape, scale_index,
                        prefix, verbose):
         reference_frame = build_patch_reference_frame(
-            reference_shape, patch_size=self.patch_size[scale_index])
+            reference_shape, patch_shape=self.patch_shape[scale_index])
         shape = template.landmarks[group].lms
         return warp_images([template], [shape], reference_frame, self.transform,
                            prefix=prefix, verbose=verbose)
@@ -383,7 +383,7 @@ class MaskedATM(ATM):
         landmarks = template.landmarks['source'].lms
 
         reference_frame = build_patch_reference_frame(
-            shape_instance, patch_size=self.patch_size)
+            shape_instance, patch_shape=self.patch_shape)
 
         transform = self.transform(
             reference_frame.landmarks['source'].lms, landmarks)
@@ -468,9 +468,9 @@ class LinearMaskedATM(ATM):
 
     def __init__(self, template, shapes, group=None, verbose=False,
                  holistic_features=no_op, diagonal=None, scales=(0.5, 1.0),
-                 patch_size=(17, 17), max_shape_components=None,
+                 patch_shape=(17, 17), max_shape_components=None,
                  batch_size=None):
-        self.patch_size = checks.check_patch_size(patch_size, len(scales))
+        self.patch_shape = checks.check_patch_shape(patch_shape, len(scales))
 
         super(LinearMaskedATM, self).__init__(
             template, shapes, group=group, verbose=verbose,
@@ -491,7 +491,7 @@ class LinearMaskedATM(ATM):
         mean_aligned_shape = mean_pointcloud(align_shapes(shapes))
         self.n_landmarks = mean_aligned_shape.n_points
         self.reference_frame = build_patch_reference_frame(
-            mean_aligned_shape, patch_size=self.patch_size[scale_index])
+            mean_aligned_shape, patch_shape=self.patch_shape[scale_index])
         dense_shapes = densify_shapes(shapes, self.reference_frame,
                                       self.transform)
         # build dense shape model
@@ -537,9 +537,9 @@ class PatchATM(ATM):
 
     def __init__(self, template, shapes, group=None, verbose=False,
                  holistic_features=no_op, patch_normalisation=no_op,
-                 diagonal=None, scales=(0.5, 1.0), patch_size=(17, 17),
+                 diagonal=None, scales=(0.5, 1.0), patch_shape=(17, 17),
                  max_shape_components=None, batch_size=None):
-        self.patch_size = checks.check_patch_size(patch_size, len(scales))
+        self.patch_shape = checks.check_patch_shape(patch_shape, len(scales))
         self.patch_normalisation = patch_normalisation
 
         super(PatchATM, self).__init__(
@@ -561,7 +561,7 @@ class PatchATM(ATM):
                        prefix, verbose):
         shape = template.landmarks[group].lms
         return extract_patches([template], [shape],
-                               self.patch_size[scale_index],
+                               self.patch_shape[scale_index],
                                normalise_function=self.patch_normalisation,
                                prefix=prefix, verbose=verbose)
 
@@ -598,10 +598,10 @@ def _atm_str(atm):
             atm.warped_templates[k].shape,
             atm.shape_models[k].n_components))
     # Patch based ATM
-    if hasattr(atm, 'patch_size'):
+    if hasattr(atm, 'patch_shape'):
         for k in range(len(scales_info)):
-            scales_info[k] += '\n   - Patch size: {}'.format(
-                atm.patch_size[k])
+            scales_info[k] += '\n   - Patch shape: {}'.format(
+                atm.patch_shape[k])
     scales_info = '\n'.join(scales_info)
 
     cls_str = r"""{class_title}

--- a/menpofit/atm/fitter.py
+++ b/menpofit/atm/fitter.py
@@ -46,7 +46,7 @@ class LucasKanadeATMFitter(ModelFitter):
             elif type(self.atm) is PatchATM:
                 pdm = OrthoPDM(sm)
                 interface = ATMLKPatchInterface(
-                    pdm, wt, sampling=s, patch_size=self.atm.patch_size[j],
+                    pdm, wt, sampling=s, patch_shape=self.atm.patch_shape[j],
                     patch_normalisation=self.atm.patch_normalisation)
                 algorithm = algorithm_cls(interface)
             else:

--- a/menpofit/builder.py
+++ b/menpofit/builder.py
@@ -159,7 +159,7 @@ def warp_images(images, shapes, reference_frame, transform, prefix='',
 
 
 # TODO: document me!
-def extract_patches(images, shapes, patch_size, normalise_function=no_op,
+def extract_patches(images, shapes, patch_shape, normalise_function=no_op,
                     prefix='', verbose=False):
     wrap = partial(print_progress,
                    prefix='{}Extracting patches'.format(prefix),
@@ -167,7 +167,7 @@ def extract_patches(images, shapes, patch_size, normalise_function=no_op,
 
     parts_images = []
     for i, s in wrap(zip(images, shapes)):
-        parts = i.extract_patches(s, patch_size=patch_size,
+        parts = i.extract_patches(s, patch_shape=patch_shape,
                                   as_single_array=True)
         parts = normalise_function(parts)
         parts_images.append(Image(parts, copy=False))
@@ -207,7 +207,7 @@ def build_reference_frame(landmarks, boundary=3, group='source'):
 
 
 def build_patch_reference_frame(landmarks, boundary=3, group='source',
-                                patch_size=(17, 17)):
+                                patch_shape=(17, 17)):
     r"""
     Builds a reference frame from a particular set of landmarks.
 
@@ -225,7 +225,7 @@ def build_patch_reference_frame(landmarks, boundary=3, group='source',
         Group that will be assigned to the provided set of landmarks on the
         reference frame.
 
-    patch_size : tuple of ints, optional
+    patch_shape : tuple of ints, optional
         Tuple specifying the shape of the patches.
 
     Returns
@@ -233,12 +233,12 @@ def build_patch_reference_frame(landmarks, boundary=3, group='source',
     patch_based_reference_frame : :map:`Image`
         The patch based reference frame.
     """
-    boundary = np.max(patch_size) + boundary
+    boundary = np.max(patch_shape) + boundary
     reference_frame = _build_reference_frame(landmarks, boundary=boundary,
                                              group=group)
 
     # mask reference frame
-    reference_frame.build_mask_around_landmarks(patch_size, group=group)
+    reference_frame.build_mask_around_landmarks(patch_shape, group=group)
 
     return reference_frame
 

--- a/menpofit/checks.py
+++ b/menpofit/checks.py
@@ -85,17 +85,17 @@ def check_scale_features(scale_features, features):
 
 
 # TODO: document me!
-def check_patch_size(patch_size, n_scales):
-    if len(patch_size) == 2 and isinstance(patch_size[0], int):
-        return [patch_size] * n_scales
-    elif len(patch_size) == 1:
-        return check_patch_size(patch_size[0], 1)
-    elif len(patch_size) == n_scales:
-        l1 = check_patch_size(patch_size[0], 1)
-        l2 = check_patch_size(patch_size[1:], n_scales-1)
+def check_patch_shape(patch_shape, n_scales):
+    if len(patch_shape) == 2 and isinstance(patch_shape[0], int):
+        return [patch_shape] * n_scales
+    elif len(patch_shape) == 1:
+        return check_patch_shape(patch_shape[0], 1)
+    elif len(patch_shape) == n_scales:
+        l1 = check_patch_shape(patch_shape[0], 1)
+        l2 = check_patch_shape(patch_shape[1:], n_scales-1)
         return l1 + l2
     else:
-        raise ValueError("patch_size must be a list/tuple of int or a "
+        raise ValueError("patch_shape must be a list/tuple of int or a "
                          "list/tuple of lit/tuple of int/float with the "
                          "same length as the number of scales")
 

--- a/menpofit/sdm/fitter.py
+++ b/menpofit/sdm/fitter.py
@@ -23,7 +23,7 @@ class SupervisedDescentFitter(MultiFitter):
     def __init__(self, images, group=None, bounding_box_group=None,
                  reference_shape=None, sd_algorithm_cls=Newton,
                  holistic_features=no_op, patch_features=no_op,
-                 patch_size=(17, 17), diagonal=None, scales=(0.5, 1.0),
+                 patch_shape=(17, 17), diagonal=None, scales=(0.5, 1.0),
                  n_iterations=6, n_perturbations=30,
                  perturb_from_bounding_box=noisy_shape_from_bounding_box,
                  batch_size=None, verbose=False):
@@ -33,14 +33,14 @@ class SupervisedDescentFitter(MultiFitter):
         n_scales = len(scales)
         patch_features = checks.check_features(patch_features, n_scales)
         holistic_features = checks.check_features(holistic_features, n_scales)
-        patch_size = checks.check_patch_size(patch_size, n_scales)
+        patch_shape = checks.check_patch_shape(patch_shape, n_scales)
         # set parameters
         self.algorithms = []
         self.reference_shape = reference_shape
         self._sd_algorithm_cls = sd_algorithm_cls
         self.holistic_features = holistic_features
         self.patch_features = patch_features
-        self.patch_size = patch_size
+        self.patch_shape = patch_shape
         self.diagonal = diagonal
         self.scales = scales
         self.n_perturbations = n_perturbations
@@ -58,7 +58,7 @@ class SupervisedDescentFitter(MultiFitter):
         for j in range(self.n_scales):
             self.algorithms.append(self._sd_algorithm_cls(
                 patch_features=self.patch_features[j],
-                patch_size=self.patch_size[j],
+                patch_shape=self.patch_shape[j],
                 n_iterations=self.n_iterations[j]))
 
     def _train(self, images, increment=False, group=None,
@@ -268,12 +268,12 @@ class SupervisedDescentFitter(MultiFitter):
         scales_info = []
         lvl_str_tmplt = r"""  - Scale {}
    - {} iterations
-   - Patch size: {}
+   - Patch shape: {}
    - Holistic feature: {}
    - Patch feature: {}"""
         for k, s in enumerate(self.scales):
             scales_info.append(lvl_str_tmplt.format(
-                s, self.n_iterations[k], self.patch_size[k],
+                s, self.n_iterations[k], self.patch_shape[k],
                 name_of_callable(self.holistic_features[k]),
                 name_of_callable(self.patch_features[k])))
         scales_info = '\n'.join(scales_info)
@@ -305,7 +305,7 @@ class RegularizedSDM(SupervisedDescentFitter):
     def __init__(self, images, group=None, bounding_box_group=None,
                  alpha=1.0, reference_shape=None,
                  holistic_features=no_op, patch_features=no_op,
-                 patch_size=(17, 17), diagonal=None, scales=(0.5, 1.0),
+                 patch_shape=(17, 17), diagonal=None, scales=(0.5, 1.0),
                  n_iterations=6, n_perturbations=30,
                  perturb_from_bounding_box=noisy_shape_from_bounding_box,
                  batch_size=None, verbose=False):
@@ -314,7 +314,7 @@ class RegularizedSDM(SupervisedDescentFitter):
             reference_shape=reference_shape,
             sd_algorithm_cls=partial(Newton, alpha=alpha),
             holistic_features=holistic_features, patch_features=patch_features,
-            patch_size=patch_size, diagonal=diagonal, scales=scales,
+            patch_shape=patch_shape, diagonal=diagonal, scales=scales,
             n_iterations=n_iterations, n_perturbations=n_perturbations,
             perturb_from_bounding_box=perturb_from_bounding_box,
             batch_size=batch_size, verbose=verbose)


### PR DESCRIPTION
This PR renames all `patch_size` occurrences to `patch_shape`, in order to be consistent. The same is done in Menpo as part of https://github.com/menpo/menpo/pull/628 PR.