### PR TITLE
Wrap dlib inside menpofit - change SDM perturbations

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -11,6 +11,7 @@ requirements:
     - python
     - menpo >=0.5.1,<0.6
     - scikit-learn 0.16.*
+    - dlib 18.16
 
 test:
   requires:

--- a/menpofit/aam/fitter.py
+++ b/menpofit/aam/fitter.py
@@ -91,11 +91,11 @@ class LucasKanadeAAMFitter(AAMFitter):
 class SupervisedDescentAAMFitter(SupervisedDescentFitter):
     r"""
     """
-    def __init__(self, images, aam, group=None, bounding_box_group=None,
+    def __init__(self, images, aam, group=None, bounding_box_group_glob=None,
                  n_shape=None, n_appearance=None, sampling=None,
                  sd_algorithm_cls=ProjectOutNewton,
                  n_iterations=6, n_perturbations=30,
-                 perturb_from_bounding_box=noisy_shape_from_bounding_box,
+                 perturb_from_gt_bounding_box=noisy_shape_from_bounding_box,
                  batch_size=None, verbose=False):
         self.aam = aam
         checks.set_models_components(aam.appearance_models, n_appearance)
@@ -106,14 +106,14 @@ class SupervisedDescentAAMFitter(SupervisedDescentFitter):
         # used because they are fully defined by the AAM already. Therefore,
         # we just leave them as their 'defaults' because they won't be used.
         super(SupervisedDescentAAMFitter, self).__init__(
-            images, group=group, bounding_box_group=bounding_box_group,
+            images, group=group, bounding_box_group_glob=bounding_box_group_glob,
             reference_shape=self.aam.reference_shape,
             sd_algorithm_cls=sd_algorithm_cls,
-            holistic_feature=self.aam.holistic_features,
+            holistic_features=self.aam.holistic_features,
             diagonal=self.aam.diagonal,
             scales=self.aam.scales, n_iterations=n_iterations,
             n_perturbations=n_perturbations,
-            perturb_from_bounding_box=perturb_from_bounding_box,
+            perturb_from_gt_bounding_box=perturb_from_gt_bounding_box,
             batch_size=batch_size, verbose=verbose)
 
     def _setup_algorithms(self):

--- a/menpofit/checks.py
+++ b/menpofit/checks.py
@@ -1,4 +1,5 @@
 import warnings
+import collections
 from functools import partial
 import numpy as np
 from menpo.shape import TriMesh
@@ -40,6 +41,29 @@ def check_scales(scales):
     else:
         raise ValueError("scales must be an int/float or a list/tuple of "
                          "int/float")
+
+
+def check_multi_scale_param(n_scales, types, param_name, param):
+    error_msg = "{0} must be in {1} or a list/tuple of " \
+                "{1} with the same length as the number " \
+                "of scales".format(param_name, types)
+
+    # Could be a single value - or we have an error
+    if isinstance(param, types):
+        return [param] * n_scales
+    elif not isinstance(param, collections.Iterable):
+        raise ValueError(error_msg)
+
+    # Must be an iterable object
+    len_param = len(param)
+    isinstance_all_in_param = all(isinstance(p, types) for p in param)
+
+    if len_param == 1 and isinstance_all_in_param:
+        return list(param) * n_scales
+    elif len_param == n_scales and isinstance_all_in_param:
+        return list(param)
+    else:
+        raise ValueError(error_msg)
 
 
 def check_features(features, n_scales):

--- a/menpofit/checks.py
+++ b/menpofit/checks.py
@@ -99,7 +99,7 @@ def check_features(features, n_scales):
 def check_scale_features(scale_features, features):
     r"""
     """
-    if np.alltrue([f == features[0] for f in features]):
+    if all(f == features[0] for f in features):
         return scale_features
     else:
         warnings.warn('scale_features has been automatically set to False '

--- a/menpofit/compatibility.py
+++ b/menpofit/compatibility.py
@@ -1,0 +1,9 @@
+import sys
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    STRING_TYPES = str
+else:
+    STRING_TYPES = basestring

--- a/menpofit/dlib/__init__.py
+++ b/menpofit/dlib/__init__.py
@@ -1,0 +1,6 @@
+try:
+    from .fitter import DlibERT
+except ImportError:
+    # If dlib is not installed then we shouldn't import anything into this
+    # module.
+    pass

--- a/menpofit/dlib/__init__.py
+++ b/menpofit/dlib/__init__.py
@@ -1,5 +1,5 @@
 try:
-    from .fitter import DlibERT
+    from .fitter import DlibERT, DlibWrapper
 except ImportError:
     # If dlib is not installed then we shouldn't import anything into this
     # module.

--- a/menpofit/dlib/__init__.py
+++ b/menpofit/dlib/__init__.py
@@ -2,5 +2,5 @@ try:
     from .fitter import DlibERT
 except ImportError:
     # If dlib is not installed then we shouldn't import anything into this
-    # module.
+    # module.
     pass

--- a/menpofit/dlib/algorithm.py
+++ b/menpofit/dlib/algorithm.py
@@ -1,0 +1,86 @@
+from __future__ import division
+import dlib
+
+from .conversion import (copy_dlib_options, pointcloud_to_dlib_rect,
+                         bounding_box_pointcloud_to_dlib_fo_detection,
+                         dlib_full_object_detection_to_pointcloud,
+                         image_to_dlib_pixels)
+from menpo.visualize import print_dynamic
+
+from menpofit.result import NonParametricAlgorithmResult
+
+
+# TODO: document me!
+class DlibAlgorithm(object):
+    r"""
+    """
+
+    def __init__(self, dlib_options, n_iterations=10):
+        self.dlib_model = None
+        self._n_iterations = n_iterations
+        self.dlib_options = copy_dlib_options(dlib_options)
+        # T from Kazemi paper - Total number of cascades
+        self.dlib_options.cascade_depth = self.n_iterations
+
+    @property
+    def n_iterations(self):
+        return self._n_iterations
+
+    @n_iterations.setter
+    def n_iterations(self, v):
+        self._n_iterations = v
+        # T from Kazemi paper - Total number of cascades
+        self.dlib_options.cascade_depth = self._n_iterations
+
+    def train(self, images, gt_shapes, bounding_boxes, prefix='',
+              verbose=False):
+
+        if verbose and self.dlib_options.oversampling_amount > 1:
+            n_menpofit_peturbations = len(bounding_boxes[0])
+            n_dlib_perturbations = self.dlib_options.oversampling_amount
+            total_perturbations = (n_menpofit_peturbations *
+                                   n_dlib_perturbations)
+            print_dynamic('{}WARNING: Dlib oversampling is being used. '
+                          '{} = {} * {} total perturbations will be generated '
+                          'by Dlib!\n'.format(prefix, total_perturbations,
+                                              n_menpofit_peturbations,
+                                              n_dlib_perturbations))
+
+        im_pixels = [image_to_dlib_pixels(im) for im in images]
+
+        detections = []
+        for bboxes, im, gt_s in zip(bounding_boxes, images, gt_shapes):
+            fo_dets = [bounding_box_pointcloud_to_dlib_fo_detection(bb, gt_s)
+                       for bb in bboxes]
+            detections.append(fo_dets)
+
+        if verbose:
+            print_dynamic('{}Performing Dlib training - please see stdout '
+                          'for verbose output provided by Dlib!'.format(prefix))
+
+        # Perform DLIB training
+        self.dlib_options.be_verbose = verbose
+        self.dlib_model = dlib.train_shape_predictor(
+            im_pixels, detections, self.dlib_options)
+
+        for bboxes, pix, fo_dets in zip(bounding_boxes, im_pixels, detections):
+            for bb, fo_det in zip(bboxes, fo_dets):
+                # Perform prediction
+                pred = dlib_full_object_detection_to_pointcloud(
+                    self.dlib_model(pix, fo_det.rect))
+                # Update bounding box in place
+                bb.from_vector_inplace(pred.bounding_box().as_vector())
+
+        if verbose:
+            print_dynamic('{}Training Dlib done.\n'.format(prefix))
+
+        return bounding_boxes
+
+    def run(self, image, bounding_box, gt_shape=None, **kwargs):
+        # Perform prediction
+        pix = image_to_dlib_pixels(image)
+        rect = pointcloud_to_dlib_rect(bounding_box)
+        pred = dlib_full_object_detection_to_pointcloud(
+            self.dlib_model(pix, rect))
+
+        return NonParametricAlgorithmResult(image, [pred], gt_shape=gt_shape)

--- a/menpofit/dlib/conversion.py
+++ b/menpofit/dlib/conversion.py
@@ -39,8 +39,8 @@ def copy_dlib_options(options):
 
 
 def image_to_dlib_pixels(im):
-    pixels = im.rolled_channels()
+    pixels = np.array(im.as_PILImage())
     # Only supports RGB and Grayscale
-    if im.n_channels == 1 or im.n_channels != 3:
+    if im.n_channels > 3:
         pixels = pixels[..., 0]
     return pixels

--- a/menpofit/dlib/conversion.py
+++ b/menpofit/dlib/conversion.py
@@ -1,0 +1,46 @@
+import dlib
+import numpy as np
+from menpo.shape import PointCloud, bounding_box
+
+
+all_parts = lambda det: ((p.y, p.x) for p in det.parts())
+
+
+def pointcloud_to_dlib_parts(pcloud):
+    return [dlib.point(int(p[1]), int(p[0])) for p in pcloud.points]
+
+
+def dlib_full_object_detection_to_pointcloud(full_object_detection):
+    return PointCloud(np.vstack(all_parts(full_object_detection)), copy=False)
+
+
+def dlib_rect_to_bounding_box(rect):
+    return bounding_box((rect.top(), rect.left()),
+                        (rect.bottom(), rect.right()))
+
+
+def pointcloud_to_dlib_rect(pg):
+    min_p, max_p = pg.bounds()
+    return dlib.rectangle(left=int(min_p[1]), top=int(min_p[0]),
+                          right=int(max_p[1]), bottom=int(max_p[0]))
+
+
+def bounding_box_pointcloud_to_dlib_fo_detection(bbox, pcloud):
+    return dlib.full_object_detection(
+        pointcloud_to_dlib_rect(bbox.bounding_box()),
+        pointcloud_to_dlib_parts(pcloud))
+
+
+def copy_dlib_options(options):
+    new_options = dlib.shape_predictor_training_options()
+    for p in sorted(filter(lambda x: '__' not in x, dir(options))):
+        setattr(new_options, p, getattr(options, p))
+    return new_options
+
+
+def image_to_dlib_pixels(im):
+    pixels = im.rolled_channels()
+    # Only supports RGB and Grayscale
+    if im.n_channels == 1 or im.n_channels != 3:
+        pixels = pixels[..., 0]
+    return pixels

--- a/menpofit/dlib/fitter.py
+++ b/menpofit/dlib/fitter.py
@@ -1,0 +1,239 @@
+from __future__ import division
+from functools import partial
+import warnings
+import dlib
+
+from .algorithm import DlibAlgorithm
+
+from menpo.feature import no_op
+from menpo.transform import Scale, AlignmentAffine
+
+from menpofit import checks
+from menpofit.fitter import noisy_shape_from_bounding_box, MultiFitter, \
+    generate_perturbations_from_gt
+from menpofit.result import MultiFitterResult
+from menpofit.builder import (
+    scale_images, rescale_images_to_reference_shape,
+    compute_reference_shape)
+
+
+class DlibERT(MultiFitter):
+    r"""
+    Dlib wrapper class.
+    """
+    def __init__(self, images, group=None, bounding_box_group_glob=None,
+                 verbose=False, reference_shape=None, diagonal=None,
+                 scales=(0.5, 1.0), n_perturbations=30, n_dlib_perturbations=1,
+                 perturb_from_gt_bounding_box=noisy_shape_from_bounding_box,
+                 n_iterations=10, feature_padding=0, n_pixel_pairs=400,
+                 distance_prior_weighting=0.1, regularisation_weight=0.1,
+                 n_split_tests=20, n_trees=500, n_tree_levels=5):
+
+        checks.check_diagonal(diagonal)
+
+        self.diagonal = diagonal
+        self.scales = checks.check_scales(scales)
+        self.holistic_features = checks.check_features(no_op, self.n_scales)
+        self.reference_shape = reference_shape
+        self.n_perturbations = n_perturbations
+        self.n_iterations = checks.check_max_iters(n_iterations, self.n_scales)
+        self._perturb_from_gt_bounding_box = perturb_from_gt_bounding_box
+        self._setup_dlib_options(feature_padding, n_pixel_pairs,
+                                 distance_prior_weighting,
+                                 regularisation_weight, n_split_tests, n_trees,
+                                 n_dlib_perturbations, n_tree_levels)
+        self._setup_algorithms()
+
+        # Train DLIB over multiple scales
+        self._train(images, group=group,
+                    bounding_box_group_glob=bounding_box_group_glob,
+                    verbose=verbose)
+
+    def _setup_algorithms(self):
+        self.algorithms = []
+        for j in range(self.n_scales):
+            self.algorithms.append(DlibAlgorithm(
+                self._dlib_options_templates[j],
+                n_iterations=self.n_iterations[j]))
+
+    def _setup_dlib_options(self, feature_padding, n_pixel_pairs,
+                            distance_prior_weighting, regularisation_weight,
+                            n_split_tests, n_trees, n_dlib_perturbations,
+                            n_tree_levels):
+        check_int = partial(checks.check_multi_scale_param, self.n_scales,
+                            (int,))
+        check_float = partial(checks.check_multi_scale_param, self.n_scales,
+                              (float,))
+        feature_padding = check_int('feature_padding', feature_padding)
+        n_pixel_pairs = check_int('n_pixel_pairs', n_pixel_pairs)
+        distance_prior_weighting = check_float('distance_prior_weighting',
+                                               distance_prior_weighting)
+        regularisation_weight = check_float('regularisation_weight',
+                                            regularisation_weight)
+        n_split_tests = check_int('n_split_tests', n_split_tests)
+        n_trees = check_int('n_trees', n_trees)
+        n_dlib_perturbations = check_int('n_dlib_perturbations',
+                                         n_dlib_perturbations)
+        n_tree_levels = check_int('n_tree_levels', n_tree_levels)
+        self._dlib_options_templates = []
+        for j in range(self.n_scales):
+            new_opts = dlib.shape_predictor_training_options()
+
+            # Size of region within which to sample features for the feature
+            # pool, e.g a padding of 0.5 would cause the algorithm to sample
+            # pixels from a box that was 2x2 pixels
+            new_opts.feature_pool_region_padding = feature_padding[j]
+            # P parameter form Kazemi paper
+            new_opts.feature_pool_size = n_pixel_pairs[j]
+            # Controls how tight the feature sampling should be. Lower values
+            # enforce closer features. Opposite of explanation from Kazemi
+            # paper, lambda
+            new_opts.lambda_param = distance_prior_weighting[j]
+            # Boosting regularization parameter - nu from Kazemi paper, larger
+            # values may cause overfitting but improve performance on training
+            # data
+            new_opts.nu = regularisation_weight[j]
+            # S from Kazemi paper - Number of split features at each node to
+            # sample. The one that gives the best split is chosen.
+            new_opts.num_test_splits = n_split_tests[j]
+            # K from Kazemi paper - number of weak regressors
+            new_opts.num_trees_per_cascade_level = n_trees[j]
+            # R from Kazemi paper - amount of times other shapes are sampled
+            # as example initialisations
+            new_opts.oversampling_amount = n_dlib_perturbations[j]
+            # F from Kazemi paper - number of levels in the tree (depth of tree)
+            new_opts.tree_depth = n_tree_levels[j]
+
+            self._dlib_options_templates.append(new_opts)
+
+    def _train(self, original_images, group=None, bounding_box_group_glob=None,
+               verbose=False):
+        r"""
+        """
+        # Dlib does not support incremental builds, so we must be passed a list
+        original_images = list(original_images)
+        # We use temporary landmark groups - so we need the group key to not be
+        # None
+        if group is None:
+            group = original_images[0].landmarks.group_labels[0]
+
+        # Temporarily store all the bounding boxes for rescaling
+        for i in original_images:
+            i.landmarks['__gt_bb'] = i.landmarks[group].lms.bounding_box()
+
+        if self.reference_shape is None:
+            # If no reference shape was given, use the mean of the first batch
+            self.reference_shape = compute_reference_shape(
+                [i.landmarks['__gt_bb'].lms for i in original_images],
+                self.diagonal, verbose=verbose)
+
+        # Rescale to existing reference shape
+        images = rescale_images_to_reference_shape(
+            original_images, '__gt_bb', self.reference_shape,
+            verbose=verbose)
+
+        # Scaling is done - remove temporary gt bounding boxes
+        for i, i2 in zip(original_images, images):
+            del i.landmarks['__gt_bb']
+            del i2.landmarks['__gt_bb']
+
+        generated_bb_func = generate_perturbations_from_gt(
+            images, self.n_perturbations, self._perturb_from_gt_bounding_box,
+            gt_group=group, bb_group_glob=bounding_box_group_glob,
+            verbose=verbose)
+
+        # for each scale (low --> high)
+        current_bounding_boxes = []
+        for j in range(self.n_scales):
+            if verbose:
+                if len(self.scales) > 1:
+                    scale_prefix = '  - Scale {}: '.format(j)
+                else:
+                    scale_prefix = '  - '
+            else:
+                scale_prefix = None
+
+            # handle scales
+            if self.scales[j] != 1:
+                # Scale feature images only if scale is different than 1
+                scaled_images = scale_images(images, self.scales[j],
+                                             prefix=scale_prefix,
+                                             verbose=verbose)
+            else:
+                scaled_images = images
+
+            if j == 0:
+                current_bounding_boxes = [generated_bb_func(im)
+                                          for im in scaled_images]
+
+            # Extract scaled ground truth shapes for current scale
+            scaled_gt_shapes = [i.landmarks[group].lms for i in scaled_images]
+
+            # Train the Dlib model
+            current_bounding_boxes = self.algorithms[j].train(
+                scaled_images, scaled_gt_shapes, current_bounding_boxes,
+                prefix=scale_prefix, verbose=verbose)
+
+            # Scale current shapes to next resolution, don't bother
+            # scaling final level
+            if j != (self.n_scales - 1):
+                transform = Scale(self.scales[j + 1] / self.scales[j],
+                                  n_dims=2)
+                for bboxes in current_bounding_boxes:
+                    for bb in bboxes:
+                        transform.apply_inplace(bb)
+
+    @property
+    def n_scales(self):
+        """
+        The number of scales of the Dlib fitter.
+
+        :type: `int`
+        """
+        return len(self.scales)
+
+    def perturb_from_bb(self, gt_shape, bb):
+        return self._perturb_from_gt_bounding_box(gt_shape, bb)
+
+    def perturb_from_gt_bb(self, gt_bb):
+            return self._perturb_from_gt_bounding_box(gt_bb, gt_bb)
+
+    def _fitter_result(self, image, algorithm_results, affine_correction,
+                       gt_shape=None):
+        return MultiFitterResult(image, self, algorithm_results,
+                                 affine_correction, gt_shape=gt_shape)
+
+    def fit_from_shape(self, image, initial_shape, max_iters=20, gt_shape=None,
+                       crop_image=None, **kwargs):
+
+        warnings.warn('Fitting from an initial shape is not supported by '
+                      'Dlib - therefore we are falling back to the tightest '
+                      'bounding box from the given initial_shape')
+        tightest_bb = initial_shape.bounding_box()
+        return self.fit_from_bb(image, tightest_bb, max_iters=max_iters,
+                                gt_shape=gt_shape, crop_image=crop_image,
+                                **kwargs)
+
+    def fit_from_bb(self, image, bounding_box, max_iters=20, gt_shape=None,
+                    crop_image=None, **kwargs):
+        # generate the list of images to be fitted
+        images, bounding_boxes, gt_shapes = self._prepare_image(
+            image, bounding_box, gt_shape=gt_shape, crop_image=crop_image)
+
+        # work out the affine transform between the initial shape of the
+        # highest pyramidal level and the initial shape of the original image
+        affine_correction = AlignmentAffine(bounding_boxes[-1], bounding_box)
+
+        # run multilevel fitting
+        algorithm_results = self._fit(images, bounding_boxes[0],
+                                      max_iters=max_iters,
+                                      gt_shapes=gt_shapes, **kwargs)
+
+        # build multilevel fitting result
+        fitter_result = self._fitter_result(
+            image, algorithm_results, affine_correction, gt_shape=gt_shape)
+
+        return fitter_result
+
+    def __str__(self):
+        return ''

--- a/menpofit/fitter.py
+++ b/menpofit/fitter.py
@@ -361,7 +361,7 @@ def noisy_target_alignment_transform(source, target,
 
 
 def noisy_shape_from_bounding_box(shape, bounding_box, noise_type='uniform',
-                                  noise_percentage=0.1, rotation=False):
+                                  noise_percentage=0.05, rotation=False):
     transform = noisy_alignment_similarity_transform(
         shape.bounding_box(), bounding_box, noise_type=noise_type,
         noise_percentage=noise_percentage, rotation=rotation)
@@ -369,7 +369,7 @@ def noisy_shape_from_bounding_box(shape, bounding_box, noise_type='uniform',
 
 
 def noisy_shape_from_shape(reference_shape, shape, noise_type='uniform',
-                           noise_percentage=0.1, rotation=False):
+                           noise_percentage=0.05, rotation=False):
     transform = noisy_alignment_similarity_transform(
         reference_shape, shape, noise_type=noise_type,
         noise_percentage=noise_percentage, rotation=rotation)


### PR DESCRIPTION
We have two dlib wrappers:

  - Train a new multi-scale dlib model. This acts much more like a normal menpofit fitter, where dlib basically just acts as the regressor.
  - A plain dlib wrapper, which just wraps a dlib model and allows fitting using menpo objects and returns fitting results.

The other major change is in the way we generate perturbations. The paragraph below is taken directly from the commit that adds the new perturbation generation function:

>> This method abstracts out the concept of generating bounding boxes
from a set of images. There are now a few different cases:

>> - You can pass a bounding box glob. This glob is used to find
   all bounding boxes that may have been provided. Useful if
   you have a number of possible detections from a detector say.
   Works really well with menpodetect returned detections.
>> - If you pass no glob, then perturbations are generated using
   the ground truth bounding box.
>> - If you pass a glob, perturbations are generated from EACH
   bounding box. This is assumed because you may have some logic
   you wish to apply and it may be repeated per box. Also, each
   provided box is included (so you get n_perturbations +
   n_provided_boxes)
>> - Now, the bounding box perturbation function should expect
   the ground truth shape and a bounding box. This should be
   flexible enough to allow any complex logic about shifting the
   box according to the ground truth. The default methods just
   take the bounding box of the ground truth and noisy align it.