### PR TITLE
Warp landmarks argument

### DIFF
--- a/menpofit/aam/algorithm/lk.py
+++ b/menpofit/aam/algorithm/lk.py
@@ -75,7 +75,8 @@ class LucasKanadeBaseInterface(object):
                                                dW_dp.shape[2]))
 
     def warp(self, image):
-        return image.warp_to_mask(self.template.mask, self.transform)
+        return image.warp_to_mask(self.template.mask, self.transform,
+                                  warp_landmarks=False)
 
     def gradient(self, img):
         nabla = fast_gradient(img)

--- a/menpofit/aam/algorithm/sd.py
+++ b/menpofit/aam/algorithm/sd.py
@@ -48,8 +48,8 @@ class SupervisedDescentStandardInterface(object):
         return self.appearance_model.n_active_components
 
     def warp(self, image):
-        return image.warp_to_mask(self.template.mask,
-                                  self.transform)
+        return image.warp_to_mask(self.template.mask, self.transform,
+                                  warp_landmarks=False)
 
     def algorithm_result(self, image, shape_parameters,
                          appearance_parameters=None, gt_shape=None):

--- a/menpofit/lk/algorithm.py
+++ b/menpofit/lk/algorithm.py
@@ -35,7 +35,8 @@ class ForwardAdditive(LucasKanade):
         # Forward Compositional Algorithm
         while k < max_iters and eps > self.eps:
             # warp image
-            IWxp = image.warp_to_mask(self.template.mask, self.transform)
+            IWxp = image.warp_to_mask(self.template.mask, self.transform,
+                                      warp_landmarks=False)
 
             # compute warp jacobian
             dW_dp = np.rollaxis(
@@ -106,7 +107,8 @@ class ForwardCompositional(LucasKanade):
         # Forward Compositional Algorithm
         while k < max_iters and eps > self.eps:
             # warp image
-            IWxp = image.warp_to_mask(self.template.mask, self.transform)
+            IWxp = image.warp_to_mask(self.template.mask, self.transform,
+                                      warp_landmarks=False)
 
             # compute steepest descent images
             filtered_J, J = self.residual.steepest_descent_images(
@@ -175,7 +177,8 @@ class InverseCompositional(LucasKanade):
         # Baker-Matthews, Inverse Compositional Algorithm
         while k < max_iters and eps > self.eps:
             # warp image
-            IWxp = image.warp_to_mask(self.template.mask, self.transform)
+            IWxp = image.warp_to_mask(self.template.mask, self.transform,
+                                      warp_landmarks=False)
 
             # compute steepest descent parameter updates.
             sd_dp = self.residual.steepest_descent_update(


### PR DESCRIPTION
In a recent Menpo PR, we changed the default `warp_landmarks` argument value of `warp_to_shape()` and `warp_to_mask()` to ``True``. This broke some stuff in Menpofit. This PR explicitly sets `warp_landmarks=False` wherever is neccessary.