### PR TITLE
Avoid copying to a new list in DlibERT _train() if unnecessary.

### DIFF
--- a/menpofit/dlib/fitter.py
+++ b/menpofit/dlib/fitter.py
@@ -113,7 +113,8 @@ class DlibERT(MultiFitter):
         r"""
         """
         # Dlib does not support incremental builds, so we must be passed a list
-        original_images = list(original_images)
+        if not isinstance(original_images, list):
+            original_images = list(original_images)
         # We use temporary landmark groups - so we need the group key to not be
         # None
         if group is None:


### PR DESCRIPTION
Copying to a new list at that point seems unnecessary, if it's already a list. Plus it takes a lot of memory if the original_images has several thousands of images. 