### PR TITLE
Remove crop_image argument from fit methods

### DIFF
--- a/docs/source/userguide/fitting.rst
+++ b/docs/source/userguide/fitting.rst
@@ -61,14 +61,14 @@ the model to an image:
 .. code-block:: python
 
     result = fitter.fit_from_shape(image, initial_shape, max_iters=20, gt_shape=None,
-                                   crop_image=None, "**"kwargs)
+                                   **kwargs)
 
 or
 
 .. code-block:: python
 
     result = fitter.fit_from_bb(image, bounding_box, max_iters=20, gt_shape=None,
-                                crop_image=None, "**"kwargs)
+                                **kwargs)
 
 They only differ on the type of initialisation. ``fit_from_shape`` expects a
 `PointCloud` as the `initial_shape`. On the other hand, the `bounding_box`
@@ -90,12 +90,6 @@ methods of **menpodetect**. The rest of the options are:
   The ground truth shape associated to the image. This is *only* useful to
   compute the final fitting error. It is *not* used, of course, at any
   internal stage of the optimisation.
-**crop_image** (`None` or `float`)
-  If `float`, it specifies the proportion of the border wrt the initial shape
-  to which the image will be internally cropped around the initial shape
-  range. If `None` , no cropping is performed. This limits the fitting
-  algorithm search region but is likely to speed up its running time,
-  specially when the modeled object occupies a small portion of the image.
 **kwargs** (`dict`)
   Additional keyword arguments that can be passed to specific models.
 

--- a/menpofit/dlib/fitter.py
+++ b/menpofit/dlib/fitter.py
@@ -320,8 +320,7 @@ class DlibERT(MultiScaleNonParametricFitter):
                         images[jj].landmarks[c_key] = \
                             scale_transforms[jj].apply(bbox)
 
-    def fit_from_shape(self, image, initial_shape, gt_shape=None,
-                       crop_image=None):
+    def fit_from_shape(self, image, initial_shape, gt_shape=None):
         r"""
         Fits the model to an image. Note that it is not possible to
         initialise the fitting process from a shape. Thus, this method raises a
@@ -338,13 +337,6 @@ class DlibERT(MultiScaleNonParametricFitter):
             bounding box.
         gt_shape : `menpo.shape.PointCloud`, optional
             The ground truth shape associated to the image.
-        crop_image : ``None`` or `float`, optional
-            If `float`, it specifies the proportion of the border wrt the
-            initial shape to which the image will be internally cropped around
-            the initial shape range. If ``None``, no cropping is performed.
-            This will limit the fitting algorithm search region but is
-            likely to speed up its running time, specially when the
-            modeled object occupies a small portion of the image.
 
         Returns
         -------
@@ -355,10 +347,9 @@ class DlibERT(MultiScaleNonParametricFitter):
                       'Dlib - therefore we are falling back to the tightest '
                       'bounding box from the given initial_shape')
         tightest_bb = initial_shape.bounding_box()
-        return self.fit_from_bb(image, tightest_bb, gt_shape=gt_shape,
-                                crop_image=crop_image)
+        return self.fit_from_bb(image, tightest_bb, gt_shape=gt_shape)
 
-    def fit_from_bb(self, image, bounding_box, gt_shape=None, crop_image=None):
+    def fit_from_bb(self, image, bounding_box, gt_shape=None):
         r"""
         Fits the model to an image given an initial bounding box.
 
@@ -371,13 +362,6 @@ class DlibERT(MultiScaleNonParametricFitter):
             will start.
         gt_shape : `menpo.shape.PointCloud`, optional
             The ground truth shape associated to the image.
-        crop_image : ``None`` or `float`, optional
-            If `float`, it specifies the proportion of the border wrt the
-            initial shape to which the image will be internally cropped around
-            the initial shape range. If ``None``, no cropping is performed.
-            This will limit the fitting algorithm search region but is
-            likely to speed up its running time, specially when the
-            modeled object occupies a small portion of the image.
 
         Returns
         -------
@@ -395,8 +379,7 @@ class DlibERT(MultiScaleNonParametricFitter):
         # scale.
         (images, bounding_boxes, gt_shapes, affine_transforms,
          scale_transforms) = self._prepare_image(image, bounding_box,
-                                                 gt_shape=gt_shape,
-                                                 crop_image=crop_image)
+                                                 gt_shape=gt_shape)
 
         # Execute multi-scale fitting
         algorithm_results = self._fit(images=images,

--- a/menpofit/fitter.py
+++ b/menpofit/fitter.py
@@ -277,8 +277,7 @@ class MultiScaleNonParametricFitter(object):
         """
         return self._holistic_features
 
-    def _prepare_image(self, image, initial_shape, gt_shape=None,
-                       crop_image=0.5):
+    def _prepare_image(self, image, initial_shape, gt_shape=None):
         r"""
         Function the performs pre-processing on the image to be fitted. This
         involves the following steps:
@@ -301,13 +300,6 @@ class MultiScaleNonParametricFitter(object):
             will start.
         gt_shape : `menpo.shape.PointCloud`, optional
             The ground truth shape associated to the image.
-        crop_image : ``None`` or `float`, optional
-            If `float`, it specifies the proportion of the border wrt the
-            initial shape to which the image will be internally cropped around
-            the initial shape range. If ``None``, no cropping is performed.
-            This will limit the fitting algorithm search region but is
-            likely to speed up its running time, specially when the
-            modeled object occupies a small portion of the image.
 
         Returns
         -------
@@ -329,16 +321,10 @@ class MultiScaleNonParametricFitter(object):
         if gt_shape:
             image.landmarks['__gt_shape'] = gt_shape
 
-        # If specified, crop the image
-        tmp_image = image
-        if crop_image:
-            tmp_image = image.crop_to_landmarks_proportion(
-                crop_image, group='__initial_shape')
-
         # Rescale image wrt the scale factor between reference_shape and
         # initial_shape
-        tmp_image = tmp_image.rescale_to_pointcloud(self.reference_shape,
-                                                    group='__initial_shape')
+        tmp_image = image.rescale_to_pointcloud(self.reference_shape,
+                                                group='__initial_shape')
 
         # For each scale:
         #     1. Compute features
@@ -534,7 +520,7 @@ class MultiScaleNonParametricFitter(object):
             scale_transforms=scale_transforms, image=image, gt_shape=gt_shape)
 
     def fit_from_shape(self, image, initial_shape, max_iters=20, gt_shape=None,
-                       crop_image=None, **kwargs):
+                       **kwargs):
         r"""
         Fits the multi-scale fitter to an image given an initial shape.
 
@@ -551,13 +537,6 @@ class MultiScaleNonParametricFitter(object):
             then specifies the maximum number of iterations per scale.
         gt_shape : `menpo.shape.PointCloud`, optional
             The ground truth shape associated to the image.
-        crop_image : ``None`` or `float`, optional
-            If `float`, it specifies the proportion of the border wrt the
-            initial shape to which the image will be internally cropped around
-            the initial shape range. If ``None``, no cropping is performed.
-            This will limit the fitting algorithm search region but is
-            likely to speed up its running time, specially when the
-            modeled object occupies a small portion of the image.
         kwargs : `dict`, optional
             Additional keyword arguments that can be passed to specific
             implementations.
@@ -579,8 +558,7 @@ class MultiScaleNonParametricFitter(object):
         # scale.
         (images, initial_shapes, gt_shapes, affine_transforms,
          scale_transforms) = self._prepare_image(image, initial_shape,
-                                                 gt_shape=gt_shape,
-                                                 crop_image=crop_image)
+                                                 gt_shape=gt_shape)
 
         # Execute multi-scale fitting
         algorithm_results = self._fit(images=images,
@@ -598,7 +576,7 @@ class MultiScaleNonParametricFitter(object):
                                    gt_shape=gt_shape)
 
     def fit_from_bb(self, image, bounding_box, max_iters=20, gt_shape=None,
-                    crop_image=None, **kwargs):
+                    **kwargs):
         r"""
         Fits the multi-scale fitter to an image given an initial bounding box.
 
@@ -616,13 +594,6 @@ class MultiScaleNonParametricFitter(object):
             then specifies the maximum number of iterations per scale.
         gt_shape : `menpo.shape.PointCloud`, optional
             The ground truth shape associated to the image.
-        crop_image : ``None`` or `float`, optional
-            If `float`, it specifies the proportion of the border wrt the
-            initial shape to which the image will be internally cropped around
-            the initial shape range. If ``None`` , no cropping is performed.
-            This will limit the fitting algorithm search region but is
-            likely to speed up its running time, specially when the
-            modeled object occupies a small portion of the image.
         kwargs : `dict`, optional
             Additional keyword arguments that can be passed to specific
             implementations.
@@ -637,7 +608,7 @@ class MultiScaleNonParametricFitter(object):
                                                       bounding_box)
         return self.fit_from_shape(image=image, initial_shape=initial_shape,
                                    max_iters=max_iters, gt_shape=gt_shape,
-                                   crop_image=crop_image, **kwargs)
+                                   **kwargs)
 
 
 class MultiScaleParametricFitter(MultiScaleNonParametricFitter):


### PR DESCRIPTION
The latest changes on how to scale the iteration shapes for the final fitting result, as well as between levels introduced a bug in case the `crop_image` argument of `fit_from_shape` and `fit_from_bb` methods is used (thanks @grigorisg9gr for spotting that!). To actually keep the argument's functionality would overcomplicate things, since we would have to store the affine transforms from the original image level to the rescaled level, as well as the transforms between the cropped images of each level. 

After discussing with @patricksnape and @grigorisg9gr , we decided to completely remove this argument from the functions. It is not that useful, and its functionality can always be implemented with something like:

```python
# Attach initial shape, crop image and remove initial shape
test_image.landmarks['initial_shape'] = initial_shape
test_image_to_fit, crop_transform = test_image.crop_to_landmarks_proportion(
    0.1, group='initial_shape', return_transform=True)
initial_shape_to_fit = test_image_to_fit.landmarks['initial_shape'].lms
del test_image.landmarks['initial_shape']

# Fit
fitting_result = fitter.fit_from_shape(test_image_to_fit, 
                                       initial_shape=initial_shape_to_fit)

# Rescale final shape to original image space
final_shape = crop_transform.apply(fitting_result.final_shape)

# View result
test_image.view()
final_shape.view()
```