### PR TITLE
Fix Bug: None check at max_appearance_components

### DIFF
--- a/menpofit/aam/base.py
+++ b/menpofit/aam/base.py
@@ -257,7 +257,7 @@ class AAM(object):
             if not increment:
                 appearance_model = PCAModel(warped_images)
                 # trim appearance model if required
-                if self.max_appearance_components is not None:
+                if self.max_appearance_components[j] is not None:
                     appearance_model.trim_components(
                         self.max_appearance_components[j])
                 # add appearance model to the list
@@ -268,7 +268,7 @@ class AAM(object):
                     warped_images,
                     forgetting_factor=appearance_forgetting_factor)
                 # trim appearance model if required
-                if self.max_appearance_components is not None:
+                if self.max_appearance_components[j] is not None:
                     self.appearance_models[j].trim_components(
                         self.max_appearance_components[j])
 


### PR DESCRIPTION
When training an AAM, the following code does checks for `max_appearance_components`:

```python
if self.max_appearance_components is not None:
    self.appearance_models[j].trim_components(
         self.max_appearance_components[j])
```

but when constructing AAM with the default `max_appearance_components=None` gives:

`self.max_appearance_components = [None, None, ...]`

which makes the above condition fail.

This means that the appearance basis is trimmed by default based on `n_active_components`, which gets set following use of the model in fitting to different values. This means incrementing an AAM after fitting will have broken trim behaviour.

This PR fix this check.