### PR TITLE
Depend on menpo 0.7, pandas optional dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   matrix:
     - PYTHON_VERSION: 2.7
     - PYTHON_VERSION: 3.4
+    - PYTHON_VERSION: 3.5
 
 install:
 - wget https://raw.githubusercontent.com/menpo/condaci/v0.4.8/condaci.py -O condaci.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
   matrix:
     - PYTHON_VERSION: 2.7
     - PYTHON_VERSION: 3.4
+    - PYTHON_VERSION: 3.5
 
 matrix:
   fast_finish: true
@@ -34,4 +35,3 @@ notifications:
     on_build_status_changed: true
     on_build_success: false
     on_build_failure: false
-

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -9,9 +9,9 @@ requirements:
 
   run:
     - python
-    - menpo 0.6.*
+    - menpo 0.7.*
     - scikit-learn >=0.17,<0.18
-    - dlib 18.16
+    - dlib 18.18
     - pandas 0.17.*
 
 test:

--- a/menpofit/visualize/textutils.py
+++ b/menpofit/visualize/textutils.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 import numpy as np
-import pandas as pn
 
 from menpo.visualize import print_progress as menpo_print_progress
 
@@ -194,6 +193,7 @@ def statistics_table(errors, method_names, auc_max_error, auc_error_step,
 
     """
     from menpofit.error import compute_statistical_measures
+    import pandas as pn
 
     # Make sure errors is a list of lists
     if not isinstance(errors[0], list):

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ setup(
       author='The Menpo Development Team',
       author_email='james.booth08@imperial.ac.uk',
       packages=find_packages(),
-      install_requires=['menpo>=0.6,<0.7',
-                        'scikit-learn>=0.17,<0.18',
-                        'pandas>=0.17,<0.18'],
+      install_requires=['menpo>=0.7,<0.8',
+                        'scikit-learn>=0.17,<0.18'],
       tests_require=['nose', 'mock']
 )


### PR DESCRIPTION
This moved menpofit master to depend on menpo 0.7 (which is pre-release at this stage). It also removes a hard dependency on pandas.