### PR TITLE
Pre-processing image for PickleWrappedFitter

### DIFF
--- a/menpofit/aam/pretrained.py
+++ b/menpofit/aam/pretrained.py
@@ -5,8 +5,13 @@ def load_balanced_frontal_face_fitter():
     r"""
     Loads a frontal face patch-based AAM fitter that is a good compromise
     between model size, fitting time and fitting performance. The model returns
-    68 facial landmark points (the standard IBUG68 markup). The model is a
-    :map:`PatchAAM` trained using the following parameters:
+    68 facial landmark points (the standard IBUG68 markup).
+
+    Note that the first time you invoke this function, menpofit will
+    download the fitter from Menpo's server. The fitter will then be stored
+    locally for future use.
+
+    The model is a :map:`PatchAAM` trained using the following parameters:
 
         =================== =================================
         Parameter           Value
@@ -33,9 +38,9 @@ def load_balanced_frontal_face_fitter():
       sampling_grid[::sampling_step, ::sampling_step] = True
       sampling = [sampling_grid, sampling_grid]
 
-    Note that the first time you invoke this function, menpofit will
-    download the fitter from Menpo's server. The fitter will then be stored
-    locally for future use.
+    Additionally, it is trained on LFPW trainset, HELEN trainset, IBUG and AFW
+    datasets (3283 images in total), which are hosted in
+    http://ibug.doc.ic.ac.uk/resources/facial-point-annotations/.
 
     Returns
     -------

--- a/menpofit/io.py
+++ b/menpofit/io.py
@@ -7,8 +7,11 @@ try:
 except ImportError:
     from urllib.request import urlopen  # Py3
 
-from menpofit.base import menpofit_src_dir_path
 from menpo.io import import_pickle
+from menpo.transform import Translation
+
+from menpofit.base import menpofit_src_dir_path
+from menpofit.result import Result
 
 # The remote URL that should be queried to download pre-trained models
 MENPO_URL = 'http://static.menpo.org'
@@ -17,6 +20,71 @@ MENPO_URL = 'http://static.menpo.org'
 # This needs to be bumped every time an existing remote model is no longer
 # Compatible with this version of menpofit.
 MENPOFIT_BINARY_VERSION = 0
+
+
+def image_greyscale_rescale_preprocess(image, pointcloud, proportion_thresh=0.1,
+                                       crop_proportion=0.3, diagonal=200):
+    r"""
+    Pre-processing function for a given test image. The function does the
+    following:
+
+    1. If image is RGB, convert it to greyscale.
+    2. If the proportion of the pointcloud's size with respect to the image's
+       size is too small, then crop the image.
+    3. If the diagonal of the pointcloud's bounding box is too large,
+       then rescale the image.
+
+    The method returns a pre-processed copy of the input image and the total
+    transform object that was applied on it.
+
+    Parameters
+    ----------
+    image : `menpo.image.Image` or subclass
+        The input test image.
+    pointcloud : `menpo.shape.PointCloud` or subclass
+        The pointcloud with respect to which the pre-processing is applied.
+        It is normally the initial pointcloud of the fitting procedure.
+    proportion_thresh : `float`, optional
+        The threshold of the proportion between the pointcloud's size and the
+        image's size.
+    crop_proportion : `float`, optional
+        The padding to add around the pointcloud as a proportion of the
+        pointcloud's size, in case the image gets cropped.
+    diagonal : `int`, optional
+        The diagonal to impose on the image.
+
+    Returns
+    -------
+    new_image : `menpo.image.Image` or subclass
+        The pre-processed image.
+    trans : `menpo.transform.Homogeneous`
+        The transform that was applied on the image.
+    """
+    # Convert image to greyscale
+    if image.n_channels == 3:
+        new_image = image.as_greyscale(mode='luminosity')
+    else:
+        new_image = image.copy()
+
+    # Assign pointcloud
+    new_image.landmarks['__pointcloud'] = pointcloud
+
+    # Crop image if initialization is much smaller than image size
+    init_range = pointcloud.range()
+    if (init_range[0] / float(image.shape[0]) > proportion_thresh or
+            init_range[1] / float(image.shape[1]) > proportion_thresh):
+        new_image, trans = new_image.crop_to_landmarks_proportion(
+            crop_proportion, group='__pointcloud', return_transform=True)
+    else:
+        trans = Translation.init_identity(pointcloud.n_dims)
+
+    # Rescale image if diagonal is too big
+    if new_image.diagonal() > diagonal:
+        new_image, rescale_trans = new_image.rescale_to_diagonal(
+            diagonal, return_transform=True)
+        trans = trans.compose_after(rescale_trans)
+
+    return new_image, trans
 
 
 class PickleWrappedFitter(object):
@@ -80,6 +148,18 @@ class PickleWrappedFitter(object):
         but can still be overridden at call time (e.g.
         ``self.fit_from_shape(image, shape, max_iters=[50, 50])`` would take
         precedence over the max_iters in the above example)
+    image_preprocess : `callable` or ``None``, optional
+        A pre-processing function to apply on the test image before fitting. The
+        default option converts the image to greyscale. The function needs to
+        have the following signature:
+
+        .. code-block:: python
+
+            new_image, transform = image_preprocess(image, pointcloud)
+
+        where `new_image` is the pre-processed image and `transform` is the
+        `menpo.transform.Homogeneous` object that was applied on the image.
+        If ``None``, then no pre-processing is performed.
 
     Examples
     --------
@@ -117,10 +197,12 @@ class PickleWrappedFitter(object):
         fitter = mio.import_pickle('pretrained_aam.pkl')()
     """
     def __init__(self, fitter_cls, fitter_args, fitter_kwargs,
-                 fit_from_bb_kwargs, fit_from_shape_kwargs):
+                 fit_from_bb_kwargs, fit_from_shape_kwargs,
+                 image_preprocess=image_greyscale_rescale_preprocess):
         self.wrapped_fitter = fitter_cls(*fitter_args, **fitter_kwargs)
         self._fit_from_bb_kwargs = fit_from_bb_kwargs
         self._fit_from_shape_kwargs = fit_from_shape_kwargs
+        self._image_preprocess = image_preprocess
 
     def fit_from_bb(self, image, bounding_box, **kwargs):
         r"""
@@ -150,9 +232,25 @@ class PickleWrappedFitter(object):
         final_kwargs = self._fit_from_bb_kwargs.copy()
         # If the user provided kwargs at runtime, they take precedence.
         final_kwargs.update(kwargs)
-        # call the wrapped fitter with the updated kwargs
-        return self.wrapped_fitter.fit_from_bb(image, bounding_box,
-                                               **final_kwargs)
+        # check if pre-processing function exists
+        if self._image_preprocess is None:
+            # call the wrapped fitter with the updated kwargs
+            result = self.wrapped_fitter.fit_from_bb(image, bounding_box,
+                                                     **final_kwargs)
+        else:
+            # pre-process the image
+            proc_image, trans = self._image_preprocess(image, bounding_box)
+            # call the wrapped fitter with the updated kwargs
+            result = self.wrapped_fitter.fit_from_bb(
+                proc_image, proc_image.landmarks['__pointcloud'].lms,
+                **final_kwargs)
+            # update result attributes
+            result._image = image
+            result._final_shape = trans.apply(result.final_shape)
+            result._initial_shape = trans.apply(result.initial_shape)
+            if result.is_iterative:
+                result._shapes = [trans.apply(s) for s in result.shapes]
+        return result
 
     def fit_from_shape(self, image, initial_shape, **kwargs):
         r"""
@@ -181,9 +279,25 @@ class PickleWrappedFitter(object):
         final_kwargs = self._fit_from_shape_kwargs.copy()
         # If the user provided kwargs at runtime, they take precedence.
         final_kwargs.update(kwargs)
-        # call the wrapped fitter with the updated kwargs
-        return self.wrapped_fitter.fit_from_shape(image, initial_shape,
-                                                  **final_kwargs)
+        # check if pre-processing function exists
+        if self._image_preprocess is None:
+            # call the wrapped fitter with the updated kwargs
+            result = self.wrapped_fitter.fit_from_bb(image, initial_shape,
+                                                     **final_kwargs)
+        else:
+            # pre-process the image
+            proc_image, trans = self._image_preprocess(image, initial_shape)
+            # call the wrapped fitter with the updated kwargs
+            result = self.wrapped_fitter.fit_from_bb(
+                proc_image, proc_image.landmarks['__pointcloud'].lms,
+                **final_kwargs)
+            # update result attributes
+            result._image = image
+            result._final_shape = trans.apply(result.final_shape)
+            result._initial_shape = trans.apply(result.initial_shape)
+            if result.is_iterative:
+                result._shapes = [trans.apply(s) for s in result.shapes]
+        return result
 
 
 def menpofit_data_dir_path():

--- a/menpofit/io.py
+++ b/menpofit/io.py
@@ -11,7 +11,6 @@ from menpo.io import import_pickle
 from menpo.transform import Translation
 
 from menpofit.base import menpofit_src_dir_path
-from menpofit.result import Result
 
 # The remote URL that should be queried to download pre-trained models
 MENPO_URL = 'http://static.menpo.org'

--- a/menpofit/io.py
+++ b/menpofit/io.py
@@ -166,7 +166,7 @@ class PickleWrappedFitter(object):
 
     .. code-block:: python
 
-        from menpofit.io import PickleWrappedFitter
+        from menpofit.io import PickleWrappedFitter, image_greyscale_rescale_preprocess
         from functools import partial
 
         # LucasKanadeAAMFitter only takes one argument, a trained aam.
@@ -185,7 +185,8 @@ class PickleWrappedFitter(object):
         # invoked at load time
         fitter_wrapper = partial(PickleWrappedFitter, LucasKanadeAAMFitter,
                                  fitter_args, fitter_kwargs,
-                                 fit_kwargs, fit_kwargs)
+                                 fit_kwargs, fit_kwargs,
+                                 image_preprocess=image_greyscale_rescale_preprocess)
 
         # save the pickle down.
         mio.export_pickle(fitter_wrapper, 'pretrained_aam.pkl')

--- a/menpofit/io.py
+++ b/menpofit/io.py
@@ -65,15 +65,12 @@ def image_greyscale_rescale_preprocess(image, pointcloud, proportion_thresh=0.1,
     else:
         new_image = image.copy()
 
-    # Assign pointcloud
-    new_image.landmarks['__pointcloud'] = pointcloud
-
     # Crop image if initialization is much smaller than image size
     init_range = pointcloud.range()
     if (init_range[0] / float(image.shape[0]) > proportion_thresh or
             init_range[1] / float(image.shape[1]) > proportion_thresh):
-        new_image, trans = new_image.crop_to_landmarks_proportion(
-            crop_proportion, group='__pointcloud', return_transform=True)
+        new_image, trans = new_image.crop_to_pointcloud_proportion(
+            pointcloud, crop_proportion, return_transform=True)
     else:
         trans = Translation.init_identity(pointcloud.n_dims)
 
@@ -242,7 +239,7 @@ class PickleWrappedFitter(object):
             proc_image, trans = self._image_preprocess(image, bounding_box)
             # call the wrapped fitter with the updated kwargs
             result = self.wrapped_fitter.fit_from_bb(
-                proc_image, proc_image.landmarks['__pointcloud'].lms,
+                proc_image, trans.pseudoinverse().apply(bounding_box),
                 **final_kwargs)
             # update result attributes
             result._image = image
@@ -289,7 +286,7 @@ class PickleWrappedFitter(object):
             proc_image, trans = self._image_preprocess(image, initial_shape)
             # call the wrapped fitter with the updated kwargs
             result = self.wrapped_fitter.fit_from_bb(
-                proc_image, proc_image.landmarks['__pointcloud'].lms,
+                proc_image, trans.pseudoinverse().apply(initial_shape),
                 **final_kwargs)
             # update result attributes
             result._image = image


### PR DESCRIPTION
This PR adds an extra `image_preprocess` argument on `PickleWrappedFitter` to pass in a pre-processing function that is applied on the test image. The function must have the following signature:

```
new_image, transform = image_preprocess(image, pointcloud)
```
where `pointcloud` is the initialization `PointCloud` (either shape or bounding box).

The default option of `menpofit.io.image_greyscale_rescale_preprocess` does the following:

1. Converts the input `image` to greyscale if it is RGB.
2. If the proportion of the `pointcloud`'s size with respect to the `image`'s size is too small, then crop the `image`.
3. If the diagonal of the `pointcloud`'s bounding box is too large, then rescale the image.

The returned `transform` is then used within the `fit_from_*()` methods to correct the result.